### PR TITLE
feat(alipay): 优化支付宝电脑网站支付方式

### DIFF
--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/payway/AliPc.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/payway/AliPc.java
@@ -78,6 +78,12 @@ public class AliPc extends AlipayPaymentService {
             if(CS.PAY_DATA_TYPE.FORM.equals(bizRQ.getPayDataType())){
                 res.setFormContent(configContextQueryService.getAlipayClientWrapper(mchAppConfigContext).getAlipayClient().pageExecute(req).getBody());
             }else{
+                if (!"2".equals(bizRQ.getQrPayMode())) {
+                    // 不是订单码跳转
+                    model.setQrPayMode(bizRQ.getQrPayMode() == null ? "3" : bizRQ.getQrPayMode()); //订单码-跳转模式
+                    model.setQrcodeWidth(bizRQ.getWidth() == null ? 100L : bizRQ.getWidth().longValue()); //二维码宽度，修复类型不兼容问题
+                }
+
                 res.setPayUrl(configContextQueryService.getAlipayClientWrapper(mchAppConfigContext).getAlipayClient().pageExecute(req, "GET").getBody());
             }
         }catch (AlipayApiException e) {

--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/rqrs/payorder/payway/AliPcOrderRQ.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/rqrs/payorder/payway/AliPcOrderRQ.java
@@ -29,10 +29,14 @@ import lombok.Data;
  */
 @Data
 public class AliPcOrderRQ extends CommonPayDataRQ {
+    private Integer width;
+    private String qrPayMode;
 
     /** 构造函数 **/
     public AliPcOrderRQ(){
         this.setWayCode(CS.PAY_WAY_CODE.ALI_PC);
+        this.setQrPayMode("2");
+        this.setWidth(100);
     }
 
 }


### PR DESCRIPTION
当wayCode=ALI_PC，payDataType=payUrl时，channelExtra添加额外参数qrPayMode(string)，width(integer)类型，可以支持 PC 扫码支付前置模式