### PR TITLE
优化支付宝回调参数解析，增加参数格式校验

### DIFF
--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/AlipayChannelNoticeService.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/AlipayChannelNoticeService.java
@@ -23,15 +23,18 @@ import com.jeequan.jeepay.core.exception.ResponseException;
 import com.jeequan.jeepay.core.model.params.alipay.AlipayConfig;
 import com.jeequan.jeepay.core.model.params.alipay.AlipayIsvParams;
 import com.jeequan.jeepay.core.model.params.alipay.AlipayNormalMchParams;
+import com.jeequan.jeepay.core.utils.AmountUtil;
 import com.jeequan.jeepay.pay.channel.AbstractChannelNoticeService;
 import com.jeequan.jeepay.pay.model.MchAppConfigContext;
 import com.jeequan.jeepay.pay.rqrs.msg.ChannelRetMsg;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.math.BigDecimal;
 import java.util.Map;
 
 /*
@@ -45,14 +48,14 @@ import java.util.Map;
 @Slf4j
 public class AlipayChannelNoticeService extends AbstractChannelNoticeService {
 
-
     @Override
     public String getIfCode() {
         return CS.IF_CODE.ALIPAY;
     }
 
     @Override
-    public MutablePair<String, Object> parseParams(HttpServletRequest request, String urlOrderId, NoticeTypeEnum noticeTypeEnum) {
+    public MutablePair<String, Object> parseParams(HttpServletRequest request, String urlOrderId,
+            NoticeTypeEnum noticeTypeEnum) {
 
         try {
 
@@ -66,67 +69,79 @@ public class AlipayChannelNoticeService extends AbstractChannelNoticeService {
         }
     }
 
-
-
     @Override
-    public ChannelRetMsg doNotice(HttpServletRequest request, Object params, PayOrder payOrder, MchAppConfigContext mchAppConfigContext, NoticeTypeEnum noticeTypeEnum) {
+    public ChannelRetMsg doNotice(HttpServletRequest request, Object params, PayOrder payOrder,
+            MchAppConfigContext mchAppConfigContext, NoticeTypeEnum noticeTypeEnum) {
         try {
 
-            //配置参数获取
+            // 配置参数获取
             Byte useCert = null;
             String alipaySignType, alipayPublicCert, alipayPublicKey = null;
-            if(mchAppConfigContext.isIsvsubMch()){
+            String alipayAppId = null;
+            String alipaySellerId = null;
+            if (mchAppConfigContext.isIsvsubMch()) {
 
                 // 获取支付参数
-                AlipayIsvParams alipayParams = (AlipayIsvParams)configContextQueryService.queryIsvParams(mchAppConfigContext.getMchInfo().getIsvNo(), getIfCode());
+                AlipayIsvParams alipayParams = (AlipayIsvParams) configContextQueryService
+                        .queryIsvParams(mchAppConfigContext.getMchInfo().getIsvNo(), getIfCode());
                 useCert = alipayParams.getUseCert();
                 alipaySignType = alipayParams.getSignType();
                 alipayPublicCert = alipayParams.getAlipayPublicCert();
                 alipayPublicKey = alipayParams.getAlipayPublicKey();
+                alipayAppId = alipayParams.getAppId();
+                alipaySellerId = alipayParams.getPid();
 
-            }else{
+            } else {
 
                 // 获取支付参数
-                AlipayNormalMchParams alipayParams = (AlipayNormalMchParams)configContextQueryService.queryNormalMchParams(mchAppConfigContext.getMchNo(), mchAppConfigContext.getAppId(), getIfCode());
+                AlipayNormalMchParams alipayParams = (AlipayNormalMchParams) configContextQueryService
+                        .queryNormalMchParams(mchAppConfigContext.getMchNo(), mchAppConfigContext.getAppId(),
+                                getIfCode());
 
                 useCert = alipayParams.getUseCert();
                 alipaySignType = alipayParams.getSignType();
                 alipayPublicCert = alipayParams.getAlipayPublicCert();
                 alipayPublicKey = alipayParams.getAlipayPublicKey();
+                alipayAppId = alipayParams.getAppId();
             }
 
             // 获取请求参数
             JSONObject jsonParams = (JSONObject) params;
 
             boolean verifyResult;
-            if(useCert != null && useCert == CS.YES){  //证书方式
+            if (useCert != null && useCert == CS.YES) { // 证书方式
 
-                verifyResult = AlipaySignature.rsaCertCheckV1(jsonParams.toJavaObject(Map.class), getCertFilePath(alipayPublicCert),
+                verifyResult = AlipaySignature.rsaCertCheckV1(jsonParams.toJavaObject(Map.class),
+                        getCertFilePath(alipayPublicCert),
                         AlipayConfig.CHARSET, alipaySignType);
 
-            }else{
-                verifyResult = AlipaySignature.rsaCheckV1(jsonParams.toJavaObject(Map.class), alipayPublicKey, AlipayConfig.CHARSET, alipaySignType);
+            } else {
+                verifyResult = AlipaySignature.rsaCheckV1(jsonParams.toJavaObject(Map.class), alipayPublicKey,
+                        AlipayConfig.CHARSET, alipaySignType);
             }
 
-            //验签失败
-            if(!verifyResult){
+            // 验签失败
+            if (!verifyResult) {
                 throw ResponseException.buildText("ERROR");
             }
 
-            //验签成功后判断上游订单状态
+            // 验签通过后，进行业务字段二次校验（订单号/金额/appId/sellerId）
+            verifyBizParams(jsonParams, payOrder, alipayAppId, alipaySellerId);
+
+            // 验签成功后判断上游订单状态
             ResponseEntity okResponse = textResp("SUCCESS");
 
             ChannelRetMsg result = new ChannelRetMsg();
-            result.setChannelOrderId(jsonParams.getString("trade_no")); //渠道订单号
-            result.setChannelUserId(jsonParams.getString("buyer_id")); //支付用户ID
-            result.setResponseEntity(okResponse); //响应数据
+            result.setChannelOrderId(jsonParams.getString("trade_no")); // 渠道订单号
+            result.setChannelUserId(jsonParams.getString("buyer_id")); // 支付用户ID
+            result.setResponseEntity(okResponse); // 响应数据
 
             result.setChannelState(ChannelRetMsg.ChannelState.WAITING); // 默认支付中
 
-            if("TRADE_SUCCESS".equals(jsonParams.getString("trade_status"))){
+            if ("TRADE_SUCCESS".equals(jsonParams.getString("trade_status"))) {
                 result.setChannelState(ChannelRetMsg.ChannelState.CONFIRM_SUCCESS);
 
-            }else if("TRADE_CLOSED".equals(jsonParams.getString("trade_status"))){
+            } else if ("TRADE_CLOSED".equals(jsonParams.getString("trade_status"))) {
                 result.setChannelState(ChannelRetMsg.ChannelState.CONFIRM_FAIL);
 
             }
@@ -134,6 +149,44 @@ public class AlipayChannelNoticeService extends AbstractChannelNoticeService {
             return result;
         } catch (Exception e) {
             log.error("error", e);
+            throw ResponseException.buildText("ERROR");
+        }
+    }
+
+    private void verifyBizParams(JSONObject jsonParams, PayOrder payOrder, String expectedAppId,
+            String expectedSellerId) {
+
+        String reqPayOrderId = jsonParams.getString("out_trade_no");
+        if (!StringUtils.equals(payOrder.getPayOrderId(), reqPayOrderId)) {
+            log.error("支付宝回调订单号不匹配, dbPayOrderId={}, reqPayOrderId={}", payOrder.getPayOrderId(), reqPayOrderId);
+            throw ResponseException.buildText("ERROR");
+        }
+
+        String reqAmount = jsonParams.getString("total_amount");
+        String dbAmount = AmountUtil.convertCent2Dollar(payOrder.getAmount());
+        try {
+            if (StringUtils.isBlank(reqAmount) || new BigDecimal(reqAmount).compareTo(new BigDecimal(dbAmount)) != 0) {
+                log.error("支付宝回调金额不匹配, dbAmount={}, reqAmount={}, payOrderId={}", dbAmount, reqAmount,
+                        payOrder.getPayOrderId());
+                throw ResponseException.buildText("ERROR");
+            }
+        } catch (NumberFormatException ex) {
+            log.error("支付宝回调金额格式错误, reqAmount={}, payOrderId={}", reqAmount, payOrder.getPayOrderId());
+            throw ResponseException.buildText("ERROR");
+        }
+
+        String reqAppId = jsonParams.getString("app_id");
+        if (StringUtils.isNotBlank(expectedAppId) && !StringUtils.equals(expectedAppId, reqAppId)) {
+            log.error("支付宝回调appId不匹配, expectedAppId={}, reqAppId={}, payOrderId={}", expectedAppId, reqAppId,
+                    payOrder.getPayOrderId());
+            throw ResponseException.buildText("ERROR");
+        }
+
+        String reqSellerId = jsonParams.getString("seller_id");
+        if (StringUtils.isNotBlank(expectedSellerId) && StringUtils.isNotBlank(reqSellerId)
+                && !StringUtils.equals(expectedSellerId, reqSellerId)) {
+            log.error("支付宝回调sellerId不匹配, expectedSellerId={}, reqSellerId={}, payOrderId={}", expectedSellerId,
+                    reqSellerId, payOrder.getPayOrderId());
             throw ResponseException.buildText("ERROR");
         }
     }

--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/ctrl/AlipayBizController.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/ctrl/AlipayBizController.java
@@ -73,7 +73,8 @@ public class AlipayBizController extends AbstractCtrl {
     @RequestMapping("/redirectAppToAppAuth/{isvAndMchAppId}")
     public void redirectAppToAppAuth(@PathVariable("isvAndMchAppId") String isvAndMchAppId) throws IOException {
 
-        String isvNo = isvAndMchAppId.split("_")[0];
+        String[] splitState = parseIsvAndMchAppId(isvAndMchAppId);
+        String isvNo = splitState[0];
 
         AlipayIsvParams alipayIsvParams = (AlipayIsvParams) configContextQueryService.queryIsvParams(isvNo, CS.IF_CODE.ALIPAY);
         alipayIsvParams.getSandbox();
@@ -101,10 +102,14 @@ public class AlipayBizController extends AbstractCtrl {
 
             if(StringUtils.isNotEmpty(isvAndMchAppId) && StringUtils.isNotEmpty(appAuthCode)){
                 isAlipaySysAuth = false;
-                String isvNo = isvAndMchAppId.split("_")[0];
-                String mchAppId = isvAndMchAppId.split("_")[1];
+                String[] splitState = parseIsvAndMchAppId(isvAndMchAppId);
+                String isvNo = splitState[0];
+                String mchAppId = splitState[1];
 
                 MchApp mchApp = mchAppService.getById(mchAppId);
+                if(mchApp == null){
+                    throw new BizException("应用不存在");
+                }
 
                 MchAppConfigContext mchAppConfigContext = configContextQueryService.queryMchInfoAndAppInfo(mchApp.getMchNo(), mchAppId);
                 AlipayClientWrapper alipayClientWrapper = configContextQueryService.getAlipayClientWrapper(mchAppConfigContext);
@@ -158,6 +163,18 @@ public class AlipayBizController extends AbstractCtrl {
         request.setAttribute("errMsg", errMsg);
         request.setAttribute("isAlipaySysAuth", isAlipaySysAuth);
         return "channel/alipay/isvsubMchAuth";
+    }
+
+    private String[] parseIsvAndMchAppId(String isvAndMchAppId) {
+        if (StringUtils.isBlank(isvAndMchAppId)) {
+            throw new BizException("state参数为空");
+        }
+
+        String[] splitState = isvAndMchAppId.split("_", 2);
+        if (splitState.length != 2 || StringUtils.isAnyBlank(splitState[0], splitState[1])) {
+            throw new BizException("state参数格式错误");
+        }
+        return splitState;
     }
 
     /**


### PR DESCRIPTION
标题
fix(alipay): 增强支付宝回调与授权回调参数校验，修复 state 解析与支付回调误放行问题

我遇到的业务场景bug:
上周我在帮一个 ISV 下线验收支付宝代扣能力时，碰到的问题。
有个商户在移动端连续发起了两笔订单，订单回调偶尔会出现看起来正常、但内容对不上的消息，即支付宝异步通知虽然能通过验签，但 out_trade_no、total_amount、app_id 有可能不是当前这笔订单上下文里的值（这里聊过后知道是配置切换导致的问题）。原逻辑只验签就继续处理，结果系统会把这笔“看似合法”的回调按成功来回写订单状态，造成账务对账和用户支付状态出现偏差。
业务场景 : 

> 1.在支付宝支付异步通知处理流程中，需要在验签通过后确认回调内容与本地订单一致，避免将异常订单状态更新到支付单。

> 2.在支付宝 ISV/商户应用授权回调流程中，接口依赖 state=isvNo_mchAppId 传递上下文信息进行跳转和后续配置查询。

Bug : 

1. isvAndMchAppId_ 在授权回调中直接 split("_")[0] / [1]，未校验长度和空值，异常或被篡改的参数会导致运行时异常（数组越界/空指针），回调链路出现 500 或异常中断。
2. 支付宝异步回调仅做签名校验，不校验关键业务字段（订单号、金额、app_id、seller_id）是否与本地订单一致，存在“签名通过但业务内容不匹配”也被继续处理的风险，可能导致错单或账务异常。

解决方案 : 

1. 在授权控制器中新增统一参数解析校验方法，统一处理 state 并校验
2. 回调前补充商户应用存在性校验，避免查询结果为空导致后续异常。
3. 在支付宝异步通知服务中新增业务二次校验流程，验签通过后继续校验

解决后的结果 : 
支付宝异步回调这边，在验签后会继续校验 out_trade_no、total_amount、app_id、seller_id，只要有任何不一致就直接拒绝，不会误把这笔回调当成这笔订单确认成功。