### PR TITLE
feat(install): -y 无交互 + 日志落盘 + summary box；shell.md 加 5 分钟上手

### DIFF
--- a/docs/deploy/shell.md
+++ b/docs/deploy/shell.md
@@ -1,81 +1,93 @@
 # Shell 脚本一键安装
 
-> **国内镜像来源**：MySQL / Redis / RocketMQ / Nginx 以及 3 个 jeepay 应用镜像已全部默认指向 **华为云 SWR 公开仓库**（`swr.cn-south-1.myhuaweicloud.com/jeepay/*`），由计全官方维护，**公网可直接匿名拉取**，不依赖 Docker Hub，无需登录，也不需要镜像加速器。
+## 5 分钟上手
 
-> Shell 一键安装脚本默认部署 **RocketMQ**，会自动启动 `rocketmq-namesrv` 与 `rocketmq-broker`；如需改回 ActiveMQ / RabbitMQ，请同步调整脚本与 `conf/*.yml` 配置。
+在一台干净的 x86_64 服务器（CentOS / Anolis / Ubuntu / Debian）上，复制粘贴一条命令：
 
-## 架构前提
-
-| 宿主架构 | MySQL / Redis / Nginx | RocketMQ (namesrv + broker) | 是否一条命令直达 |
-|---|---|---|---|
-| `x86_64` / `amd64` | 原生运行 | 原生运行 | ✅ 直接跑脚本 |
-| `arm64` / Apple Silicon | 原生运行（SWR 已同步 amd64 + arm64 多架构 manifest） | 需 qemu/binfmt 或 Rosetta 2 仿真 | ⚠️ 必须先启用 amd64 仿真 |
-
-说明：
-
-- **RocketMQ 上游只发布 `linux/amd64` 镜像**，ARM64 宿主必须提前注册仿真层才能拉起 `rocketmq-namesrv` / `rocketmq-broker`；否则脚本会在第 5 步直接失败退出。
-- **Linux ARM64 宿主**（自建机 / 云厂商 arm 实例）：`docker run --privileged --rm tonistiigi/binfmt --install amd64` 一次即可。
-- **macOS Apple Silicon**：Docker Desktop 开启 **Use Rosetta for x86_64/amd64 emulation on Apple Silicon**。
-- 如果你自行构建了原生 arm64 的 RocketMQ 镜像，可同时覆盖 `rocketmqImage` 和 `rocketmqPlatform`：
-
-```bash
-export rocketmqImage=<你的 arm64 RocketMQ 镜像>
-export rocketmqPlatform=linux/arm64
-sh install.sh
-```
-
-## 前置依赖
-
-脚本运行过程中会使用以下命令；下表说明各自由谁负责，以避免 "minimal 镜像" 上一键命令跑到一半挂掉。
-
-| 命令 | 用途 | 负责方 |
-|---|---|---|
-| `wget` | 下载 `config.sh` 与前端静态资源包 `html.tar.gz` | **一键命令预装（必须）** |
-| `curl` | `install.sh` 结束前的部署自检 `[8]`；缺失只会让自检报 `WARN`，不影响部署本身 | 一键命令预装（建议） |
-| `git` | `git clone` 拉取 jeepay 源码 | CentOS / Anolis 上 `install.sh` 检测缺失会 `yum install -y git`；Ubuntu 路径需一键命令预装 |
-| `docker` | 启动所有容器 | CentOS / Anolis 上 `install.sh` 检测缺失会 `yum install -y docker-ce`；Ubuntu 路径需一键命令预装 |
-
-## CentOS / Anolis
-
-> 推荐系统：Anolis OS 8.8
-
+**CentOS / Anolis**
 ```bash
 yum install -y wget curl && wget -O install.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/install.sh && sh install.sh
 ```
 
-`install.sh` 内部检测到缺失会自动 `yum install` `git` 与 `docker-ce`，因此只需要预先装好 `wget` 和 `curl`。
-
-## Ubuntu
-
-> 推荐系统：Ubuntu 22.04 64 位
-
+**Ubuntu / Debian**
 ```bash
 apt update && apt-get -y install wget curl git docker.io && wget -O install.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/install.sh && sh install.sh
 ```
 
-`install.sh` 对 apt 系统没有安装兜底，因此 `docker.io` / `git` / `wget` / `curl` 必须在一键命令里装齐。
+脚本会自动识别你的系统、装齐依赖、拉镜像、起 8 个容器、跑部署自检。**默认**：
+
+| 项 | 值 |
+|---|---|
+| 安装目录 | `/jeepayhomes` |
+| 镜像来源 | `swr.cn-south-1.myhuaweicloud.com/jeepay/*`（华为云 SWR 公开仓库，免登录） |
+| MQ 方案 | RocketMQ（namesrv + broker） |
+| 源码 ref | `V3.2.7`（与业务镜像 `3.2.0` 完全兼容） |
+
+装完后访问：
+
+| 平台 | 地址 | 账号 / 密码 |
+|---|---|---|
+| 运营平台 | `http://外网IP:19217` | `jeepay` / `jeepay123` |
+| 商户系统 | `http://外网IP:19218` | 需在运营平台创建商户用户，默认密码 `jeepay666` |
+| 支付网关 / 收银台 | `http://外网IP:19216/cashier/index.html` | — |
+
+**卸载**：
+
+```bash
+wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh && sh uninstall.sh
+```
+
+---
+
+以下章节讲**默认路径之外**的场景：前置依赖细节、自检、端口冲突、HTTPS 反代、高级覆盖项、排障。
+
+## 前置依赖
+
+脚本需要的四个命令，按优先级装齐：
+
+| 命令 | 用途 | 缺失兜底 |
+|---|---|---|
+| `wget` | 下载 `install.sh` 自身、`config.sh`、前端静态资源包 | **必须由一键命令预装**（脚本本身靠 wget 启动） |
+| `curl` | `install.sh` 结束前的部署自检 `[8]` | 缺失只会让自检报 `WARN`，不影响部署本身 |
+| `git` | `git clone` 拉取 jeepay 源码 | `install.sh` 会自动识别 `apt` / `dnf` / `yum` / `apk` 并安装 |
+| `docker` | 启动所有容器 | 同上，Docker daemon 也会自动 start / enable |
+
+CentOS / Anolis 的一键命令只装 `wget curl` 是因为 `git` 和 `docker` 交给脚本；Ubuntu / Debian 的一键命令把四个都装了，是因为脚本在 minimal Ubuntu 镜像上可能先卡在 `wget -O install.sh`。
 
 ## 部署后自检
 
-`install.sh` 结束前会自动执行：
+`install.sh` 结束前会自动执行（约 30 秒）：
 
-1. 轮询 `jeepaymanager` / `jeepaymerchant` / `jeepaypayment` 的 `docker healthcheck` 状态，最长 180 秒；
-2. 探测宿主机 `19216` / `19217` / `19218` 端口的 HTTP 响应。
+1. 轮询 `jeepaymanager` / `jeepaymerchant` / `jeepaypayment` 的 `docker healthcheck` 状态（最长 180 秒）；
+2. 探测宿主机 `19216` / `19217` / `19218` 端口的 HTTP 响应；
+3. 调用运营平台 `/api/anon/auth/vercode` 接口（会触发 MySQL + Redis 通路）。
 
-若某个端口未响应或容器未进入 `healthy`，脚本会打印 `WARN` 提示，方便第一时间排查。
+任一步骤不达标会打印 `WARN` 并给排查指引。完整日志落在 `/tmp/jeepay-install-<时间戳>.log`（安装开始时脚本会在第一行打印路径，结束时 summary box 再次列出），失败时先看这个文件。
 
 ## 默认开放端口
 
 | 组件 | 端口 | 说明 |
 | --- | --- | --- |
-| MySQL | `3306` | 数据库 |
-| Redis | `6379` | 缓存 |
-| RocketMQ NameServer | `9876` | RocketMQ 注册中心 |
-| RocketMQ Broker | `10909` / `10911` / `10912` | RocketMQ Broker |
+| MySQL | `3306` | 被占时脚本自动换到 `13306` 之后 |
+| Redis | `6379` | 被占时脚本自动换到 `16379` 之后 |
+| RocketMQ NameServer | `9876` | 被占时脚本退出 |
+| RocketMQ Broker | `10909` / `10911` / `10912` | 被占时脚本退出 |
 | 支付网关 | `19216` | payment 服务 |
 | 运营平台 | `19217` | manager 服务 |
 | 商户平台 | `19218` | merchant 服务 |
-| Nginx | `80` | 前端静态资源与反向代理 |
+
+## 宿主端口冲突
+
+`install.sh` 在进入 `[1]` 之前会预检以上端口：
+
+- **MySQL / Redis** 被占时 **自动换端口**（3306 → 13306 → 13307…；6379 → 16379 …）并打印 `INFO` 继续部署，无需重跑。容器内仍是标准端口，jeepay 各服务在 `jeepay-net` 内部仍通过 `mysql:3306` / `redis:6379` 通信。
+- **RocketMQ / Nginx** 端口与容器内通信耦合（broker 会广播 `brokerIP1:10911`，nginx 的 `listen` 写进静态配置），**不支持自动换**，命中冲突请先释放占用进程再重跑：
+
+```bash
+ss -lntp | grep -E ':9876|:1091[0-2]|:1921[6-8]'
+```
+
+如果想指定固定 MySQL / Redis 宿主端口（不靠脚本自动挑），见 [高级覆盖项](#高级覆盖项)。
 
 ## 配置域名 + HTTPS
 
@@ -83,7 +95,7 @@ apt update && apt-get -y install wget curl git docker.io && wget -O install.sh h
 
 - `19217` → 运营平台静态 + `/api/` 反代到 Spring Boot `9217`；
 - `19218` → 商户平台静态 + `/api/` 反代到 Spring Boot `9218`；
-- `19216` → 整体反代到 Spring Boot `9216`（**收银台静态资源**与支付 API 均由 `jeepay-payment` 自己提供；静态页面路径为 `/cashier/index.html`，Spring Boot 没有配置目录默认首页，访问 `/cashier/` 会 404）。
+- `19216` → 整体反代到 Spring Boot `9216`（收银台静态资源与支付 API 均由 `jeepay-payment` 自己提供，静态页面路径为 `/cashier/index.html`）。
 
 三个 `server` 块都补了 `X-Forwarded-Proto` / `X-Forwarded-Port` / `X-Forwarded-For`，配合 Spring Boot 侧 `server.forward-headers-strategy: framework`（已默认开启）即可保证外层 HTTPS 反代时，收银台 `return_url` / 支付回调 URL / 微信 H5 `redirect_url` 拼出的协议与 host 始终正确。
 
@@ -97,7 +109,7 @@ apt update && apt-get -y install wget curl git docker.io && wget -O install.sh h
 | `https://mch.example.com` | 商户平台 | `http://127.0.0.1:19218` |
 | `https://pay.example.com` | 支付网关 + 收银台 | `http://127.0.0.1:19216` |
 
-外层 nginx 示例（HTTPS 终结在外层，内层按内部 80/HTTP 回源）：
+外层 nginx 示例（HTTPS 终结在外层，内层按内部 HTTP 回源）：
 
 ```nginx
 server {
@@ -124,11 +136,11 @@ server {
 
 ### 拓扑二：一个域名 + 路径前缀
 
-比如只有一个主域名 `https://www.example.com`，把三套前后端塞到子路径。这种拓扑需要同步前端构建时的 `publicPath`（`jeepay-ui` 的 `vue.config.js`）和 Spring Boot 的 `server.servlet.context-path`，否则静态资源 404 / API 404。适合**有前端构建能力**的团队，不建议新手使用。
+只有一个主域名 `https://www.example.com` 把三套前后端塞到子路径。这种拓扑需要同步前端构建时的 `publicPath`（`jeepay-ui` 的 `vue.config.js`）和 Spring Boot 的 `server.servlet.context-path`，否则静态资源 404 / API 404。适合**有前端构建能力**的团队，不建议新手使用。
 
 ### 拓扑三：只对外暴露收银台
 
-电商 / SaaS 侧最常见：只把收银台对客户暴露，运营平台 / 商户平台留在内网 / VPN / 跳板机。
+电商 / SaaS 侧最常见：只把收银台对客户暴露，运营 / 商户平台留在内网 / VPN。
 
 ```
 公网域名 https://pay.example.com  →  http://127.0.0.1:19216
@@ -138,52 +150,12 @@ server {
 
 对应的防火墙规则只放行 19216。
 
-### 注意事项
+### 反代注意事项
 
 - 外层反代务必传 `X-Forwarded-Proto $scheme`；否则 Spring Boot 会把回调 URL 拼成 `http://`，支付平台回跳失败。
 - 第三方支付平台后台填的 **异步通知 URL / 回跳 URL** 必须用公网域名（`https://pay.example.com/api/pay/...`）而不是 `http://<内网 IP>:19216`。
-- 外层 nginx 若开启 `gzip`，注意排除 SSE / WebSocket 类型（`text/event-stream`）。
+- 外层 nginx 若开启 `gzip`，注意排除 SSE / WebSocket（`text/event-stream`）。
 - 修改 `nginx.conf` 后：`docker exec nginx118 nginx -s reload`。
-
-## 宿主端口冲突
-
-`install.sh` 在进入 `[1]` 之前会预检以下宿主端口：
-
-`3306` `6379` `9876` `10909` `10911` `10912` `19216` `19217` `19218`
-
-### MySQL / Redis 冲突：**脚本自动换端口**
-
-宿主机已有 MySQL / Redis 是常见场景（通常是客户自己的业务在用）。`install.sh` 检测到默认端口被占会**自动挑选空闲端口**并打印 `INFO` 提示，后续流程正常继续：
-
-```
-INFO: 宿主端口 3306 已被占，MySQL 自动改用 13306（仅影响宿主机外部访问，不影响 jeepay 内部通信）。
-INFO: 宿主端口 6379 已被占，Redis 自动改用 16379（仅影响宿主机外部访问，不影响 jeepay 内部通信）。
-```
-
-自动选端口规则：先从默认端口开始，被占则跳到 `默认 + 10000`（例如 3306 → 13306），再被占则依次 +1。
-
-容器内仍是标准端口，jeepay 各服务在 `jeepay-net` 内部通过 `mysql:3306` / `redis:6379` 通信，host port 自动换只影响"从宿主机外部访问"的端口号。
-
-### 想指定固定端口（可选）
-
-如果对宿主端口有特定要求（比如防火墙规则 / 统一端口规划），可通过环境变量或 `config.sh` 覆盖：
-
-```bash
-export mysqlHostPort=13306
-export redisHostPort=16379
-sh install.sh
-```
-
-用户**显式指定**的端口若被占，脚本会直接报错退出（不会静默换端口），以尊重用户意图。
-
-### RocketMQ / Nginx 端口被占
-
-这几个端口与容器内通信耦合（RocketMQ broker 会向客户端广播 `brokerIP1:10911`，Nginx 的 `listen` 写进了静态配置），**不支持自动换端口**。命中冲突请先释放再重跑：
-
-```bash
-# 找占用进程并按需处理
-ss -lntp | grep -E ':9876|:1091[0-2]|:1921[6-8]'
-```
 
 ## 卸载
 
@@ -193,42 +165,49 @@ ss -lntp | grep -E ':9876|:1091[0-2]|:1921[6-8]'
 wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh && sh uninstall.sh
 ```
 
-脚本会自动从跑着的 `mysql8` 容器数据卷反推 `rootDir`，打印出来让你确认后再删容器、网络和整个 `rootDir`。幂等执行，缺失容器或网络会自动跳过。
+脚本自动从跑着的 `mysql8` 容器数据卷反推 `rootDir`，打印确认后再删容器、网络、整个 `rootDir`。
 
-若 jeepay 容器已全部被手工删除、自动识别不到，可以手动指定：
+若 jeepay 容器已全部被手工删除、自动识别不到：
 
 ```bash
 rootDir=/jeepayhomes sh uninstall.sh
 ```
 
-或者按原来的方式进入安装目录（install.sh 在那里回写了真实 `rootDir` 的 `config.sh`）：
+## 高级覆盖项
 
-```bash
-cd $rootDir/sources/jeepay/docs/install && sh uninstall.sh
-```
+绝大多数用户用默认值即可。以下变量按需通过环境变量或 [`config.sh`](../install/config.sh)（取消注释）覆盖：
 
-## 锁定源码版本
+| 变量 | 默认值 | 何时需要改 |
+|---|---|---|
+| `rootDir` | `/jeepayhomes` | 想把部署目录放到其他位置（比如 `/data/jeepay`） |
+| `mysql_pwd` | `jeepaydb123456` | 想改 MySQL root 密码 |
+| `mysqlHostPort` | `3306`（被占时自动换） | 想固定到某个特定端口（不让脚本自动挑） |
+| `redisHostPort` | `6379`（被占时自动换） | 同上 |
+| `mysqlImage` | `swr.../jeepay/mysql:8.0.25` | 切到内网镜像仓库、固定其他版本，或回 Docker Hub |
+| `redisImage` | `swr.../jeepay/redis:6.2.14` | 同上 |
+| `rocketmqImage` | `swr.../jeepay/rocketmq:5.3.1` | 同上；若使用自行构建的原生 arm64 镜像请同时改 `rocketmqPlatform` |
+| `nginxImage` | `swr.../jeepay/nginx:1.18.0` | 同上 |
+| `managerImage` / `merchantImage` / `paymentImage` | `swr.../jeepay/jeepay-*:3.2.0` | 切到自有仓库或其他版本 |
+| `rocketmqPlatform` | `linux/amd64` | 使用原生 arm64 镜像时改 `linux/arm64`（RocketMQ 上游仅发布 amd64） |
+| `jeepayRef` | `V3.2.7` | 想拉其他 release tag 或 master 分支 |
 
-`install.sh` 默认 `jeepayRef=V3.2.7`，即 `git clone --branch V3.2.7 --depth 1`，和业务镜像（`3.2.0`，V3.2.7 与之完全兼容）锁在同一版本，避免业务镜像固定而源码继续漂移出现的"老镜像 + 新配置"混装问题。
+命令行参数：
 
-如需临时改用最新 master 或其他 release tag，安装前导出环境变量即可：
+| 参数 | 作用 |
+|---|---|
+| `-y` / `--yes` | 跳过脚本中所有 yes/no 确认，适合 CI / 量产脚本 |
+| `-h` / `--help` | 打印帮助并退出 |
 
-```bash
-export jeepayRef=master      # 或改为其他目标 tag / 分支
-sh install.sh
-```
+### ARM64 / Apple Silicon 注意
 
-`config.sh` 里也有对应的注释条目，取消注释后等价。
+RocketMQ 上游**只发布 `linux/amd64`** 镜像。在 ARM64 宿主上部署需要先启用 amd64 仿真层，否则 `[5]` 会失败：
 
-## 自定义镜像源（高级）
+- Linux ARM64（自建机 / 云厂商 arm 实例）：`docker run --privileged --rm tonistiigi/binfmt --install amd64`
+- macOS Apple Silicon：Docker Desktop 开启 **Use Rosetta for x86_64/amd64 emulation**
 
-绝大多数用户直接用脚本默认镜像（华为云 SWR 公开仓库）即可。只有以下场景需要覆盖：
+其它镜像（mysql / redis / nginx / temurin）SWR 已同步 amd64 + arm64 多架构 manifest，原生运行。
 
-- 公司 / 集群有内部镜像仓库，想走内部网络；
-- 想固定到特定版本或自行构建的镜像；
-- 一定要回到 Docker Hub 上游镜像（一般不推荐，国内拉取慢且依赖加速器）。
-
-同样的覆盖项已在 [`config.sh`](../install/config.sh) 中以注释形式列出，取消注释并修改即可；或在执行前直接用环境变量覆盖：
+### 切回 Docker Hub 上游镜像示例
 
 ```bash
 export mysqlImage=mysql:8.0.25
@@ -238,16 +217,14 @@ export nginxImage=nginx:1.18.0
 export managerImage=jeepay/jeepay-manager:3.2.0
 export merchantImage=jeepay/jeepay-merchant:3.2.0
 export paymentImage=jeepay/jeepay-payment:3.2.0
-# 若使用原生 arm64 的 RocketMQ 镜像，可同时切换平台
-# export rocketmqPlatform=linux/arm64
 sh install.sh
 ```
 
 ## RocketMQ Broker 启动失败
 
-如果安装过程卡在 RocketMQ 启动阶段，脚本会自动输出最近日志并直接失败退出。优先检查：
+如果安装卡在 `[5]`，脚本会自动输出最近日志并失败退出。优先检查：
 
-1. 服务器架构是否兼容所用的 `rocketmq:5.3.1` 镜像；
+1. 服务器架构是否兼容所用的 `rocketmq:5.3.1` 镜像（ARM64 需 amd64 仿真）；
 2. `$rootDir/rocketmq/broker/store` 目录权限是否正常；
 3. `$rootDir/rocketmq/broker/conf/broker.conf` 是否成功挂载（模板写入的 `brokerIP1` 是否为当前服务器 IP）；
 4. `rocketmq-namesrv` 是否已正常启动。
@@ -257,4 +234,6 @@ sh install.sh
 ```bash
 docker logs --tail 50 rocketmq-namesrv
 docker logs --tail 100 rocketmq-broker
+# 完整安装日志（安装开始 / 结束都打印了具体路径）
+ls -lt /tmp/jeepay-install-*.log | head -1
 ```

--- a/docs/install/install.sh
+++ b/docs/install/install.sh
@@ -1,12 +1,62 @@
 #! /bin/sh
-#exec 2>>build.log  ##编译过程打印到日志文件中
 ## 一键启动jeepay服务，包含mysqlDB/RocketMQ/redis/javaservice/nginx   .Power by terrfly
 
+# ---------------------------------------------------------------------------
+# 命令行参数解析（放在 root 校验之前，便于非 root 也能 --help）
+# ---------------------------------------------------------------------------
+AUTO_YES=0
+show_usage() {
+    cat <<EOF
+用法: sh install.sh [选项]
 
-if [ $UID != '0' ]; then
+选项:
+  -y, --yes    自动确认所有 yes/no 提示，适合自动化 / CI 场景。
+  -h, --help   打印本帮助并退出。
+
+环境变量（可选，见 docs/deploy/shell.md "高级覆盖项"）：
+  rootDir / mysql_pwd                        根目录与 MySQL 密码
+  mysqlHostPort / redisHostPort              宿主端口覆盖
+  mysqlImage / redisImage / rocketmqImage    镜像覆盖
+  nginxImage / managerImage / merchantImage  镜像覆盖
+  paymentImage                               镜像覆盖
+  rocketmqPlatform                           RocketMQ 平台（默认 linux/amd64）
+  jeepayRef                                  源码 tag，默认 V3.2.7
+EOF
+}
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -y|--yes) AUTO_YES=1; shift ;;
+        -h|--help) show_usage; exit 0 ;;
+        *) echo "未知参数：$1"; show_usage; exit 1 ;;
+    esac
+done
+
+if [ "$(id -u)" != '0' ]; then
     echo 'ERROR： 请使用root用户安装（Please install using root user）！'
-    exit 0
+    exit 1
 fi
+
+# 把全部输出落盘到日志文件，失败时可回看完整上下文。
+# 选择 /tmp 是因为此时 rootDir 还没解析，/tmp 几乎肯定可写。
+INSTALL_LOG_FILE="/tmp/jeepay-install-$(date +%Y%m%d-%H%M%S)-$$.log"
+exec > >(tee -a "$INSTALL_LOG_FILE") 2>&1
+echo "安装日志将同时写入：$INSTALL_LOG_FILE"
+[ "$AUTO_YES" = "1" ] && echo "已启用 --yes 自动确认模式"
+
+# 统一的 yes/no 交互封装：--yes 模式下跳过并打印提示，保持日志上下文完整
+confirm_yes() {
+    promptMsg=$1
+    if [ -n "$promptMsg" ]; then
+        echo "$promptMsg"
+    fi
+    echo " [yes/no] ?"
+    if [ "$AUTO_YES" = "1" ]; then
+        echo "(auto-yes 自动确认)"
+        useryes=yes
+    else
+        read useryes
+    fi
+}
 
 # ---------------------------------------------------------------------------
 # 跨发行版的依赖安装辅助：检测包管理器（apt/dnf/yum/apk），对 wget/curl/git/
@@ -122,11 +172,9 @@ ensure_cmd wget
 ensure_cmd curl
 
 # 第0步：提示信息
-echo "请确认当前是全新服务器安装,  是否继续？"
-echo "(Please confirm if it is a brand new server installation, do you want to continue?)"
-echo " [yes/no] ?"
-read useryes
-if [ -z "$useryes" ] || [ $useryes != 'yes' ]
+confirm_yes "请确认当前是全新服务器安装,  是否继续？
+(Please confirm if it is a brand new server installation, do you want to continue?)"
+if [ -z "$useryes" ] || [ "$useryes" != 'yes' ]
 then
 	echo 'good bye'
 	exit 0
@@ -257,12 +305,10 @@ if [ "$portConflict" -eq 1 ]; then
 fi
 
 # 第0步：提示信息
-echo "检查配置信息是否正确（配置内容在 config.sh文件）："
-echo "【项目根目录的地址】： $rootDir"
-echo "【mysql root密码】： $mysql_pwd"
-echo " [yes/no] ?"
-read useryes
-if [ -z "$useryes" ] || [ $useryes != 'yes' ]
+confirm_yes "检查配置信息是否正确（配置内容在 config.sh文件）：
+【项目根目录的地址】： $rootDir
+【mysql root密码】： $mysql_pwd"
+if [ -z "$useryes" ] || [ "$useryes" != 'yes' ]
 then
     echo 'good bye'
     exit 0
@@ -643,13 +689,27 @@ fi
 
 echo "[8] Done. "
 
-echo ">>>>>>> "
-echo ">>>>>>> "
-echo ">>>>>>>安装完成， 所有的配置文件和项目文件都在：$rootDir 文件夹中。 "
-echo ">>>>>>>项目访问地址 （注意开通端口防火墙）：   "
-echo ">>>>>>>运营平台： http://外网IP:19217   账号密码： jeepay/jeepay123   "
-echo ">>>>>>>商户平台： http://外网IP:19218   账号密码： 需要登录运营平台手动创建。    "
-echo ">>>>>>>支付网关： http://外网IP:19216   "
-echo ">>>>>>>若配置域名请更改 $rootDir/nginx/conf/nginx.conf 配置文件。 "
+cat <<SUMMARY
+
+============================================================
+                 jeepay 安装完成
+============================================================
+ 安装目录    ： $rootDir
+ nginx 配置  ： $rootDir/nginx/conf/nginx.conf
+ 安装日志    ： $INSTALL_LOG_FILE
+
+ 访问地址（注意开通端口防火墙）：
+   运营平台 ： http://外网IP:19217   账号 / 密码 ： jeepay / jeepay123
+   商户平台 ： http://外网IP:19218   账号需在运营平台创建，默认密码 jeepay666
+   支付网关 ： http://外网IP:19216   收银台路径 /cashier/index.html
+
+ 常用命令：
+   docker ps                                查看 8 个容器状态
+   docker logs jeepaymanager --tail 100     查看某个服务日志
+   wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh \\
+     && sh uninstall.sh                     一键卸载（自动识别 rootDir）
+============================================================
+SUMMARY
+
 echo ""
 echo "Complete."


### PR DESCRIPTION
## Summary
- install.sh 加 `-y` / `--help` 参数、`/tmp` 日志落盘、结束前完整 summary box。
- docs/deploy/shell.md 最顶部加"5 分钟上手"，合并四段"高级覆盖"为一张总表。

## Test plan
- [x] 本地 `sh docs/install/test_*.sh` 三条 PASS。
- [x] 本地 `bash -n install.sh` / `sh install.sh --help` 工作性正常。
- [x] 远端端到端回归（Anolis OS，--yes 模式）：安装完整通过，summary box 与日志文件包含"Complete."，[8] 自检 DB+Redis canary 绿。
- [ ] PR 触发的 CI 两个 job 全绿。

## 不包含
- 未 bump tag。等本 PR 合并 dev 后视情况发 V3.2.8。