### PR TITLE
fix(install): RocketMQ brokerIP1 默认用容器名 rocketmq-broker，规避宿主多网卡误判

### DIFF
--- a/docs/install/install.sh
+++ b/docs/install/install.sh
@@ -510,20 +510,17 @@ cd $sourcesInstallPath && cp ./../../docker/rocketmq/broker/conf/broker.conf.tem
 require_ok $? "复制 RocketMQ broker 配置模板 broker.conf.template"
 assert_regular_file "$rootDir/rocketmq/broker/conf/broker.conf.template" "RocketMQ broker 配置模板"
 
-brokerHostIp=$(hostname -I 2>/dev/null | awk '{print $1}')
-if [ -z "$brokerHostIp" ]; then
-  brokerHostIp=$(ip route get 1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}')
-fi
+# brokerIP1 默认写容器名 rocketmq-broker：jeepay 所有业务（manager / merchant /
+# payment）都在 jeepay-net 内，通过 Docker 内置 DNS 按容器名解析最稳，不受宿主
+# 多网卡 / 多 Docker bridge 影响（老版本用 hostname -I 首项在某些宿主上会挑到
+# 172.16.0.x 这种仅 Docker 内部可达的地址，导致业务容器连 broker 失败）。
+# 如有外部 RocketMQ 客户端需求（非 jeepay-net 内），安装前 export brokerIP1=真实IP。
+brokerIP1=${brokerIP1:-rocketmq-broker}
 
-if [ -z "$brokerHostIp" ]; then
-  echo "[5] ERROR: 无法自动识别当前服务器 IP，无法生成 RocketMQ broker.conf"
-  exit 1
-fi
-
-sed "s/%BROKER_IP%/$brokerHostIp/g" \
+sed "s/%BROKER_IP%/$brokerIP1/g" \
   $rootDir/rocketmq/broker/conf/broker.conf.template > $rootDir/rocketmq/broker/conf/broker.conf
 
-echo "[5] RocketMQ brokerIP1 使用当前服务器IP: $brokerHostIp"
+echo "[5] RocketMQ brokerIP1 设为: $brokerIP1"
 
 # 启动 NameServer
 docker run -d --name rocketmq-namesrv --network=jeepay-net \

--- a/docs/install/test_install_rocketmq.sh
+++ b/docs/install/test_install_rocketmq.sh
@@ -21,8 +21,8 @@ if ! grep -q 'brokerIP1=%BROKER_IP%' "$BROKER_TEMPLATE"; then
   exit 1
 fi
 
-if ! grep -q 'hostname -I' "$INSTALL_SCRIPT"; then
-  echo "FAIL: install.sh does not detect host IP for RocketMQ broker.conf"
+if ! grep -q 'brokerIP1=\${brokerIP1:-rocketmq-broker}' "$INSTALL_SCRIPT"; then
+  echo "FAIL: install.sh does not default brokerIP1 to the broker container name (rocketmq-broker)"
   exit 1
 fi
 


### PR DESCRIPTION
## 背景
客户在新服务器部署后，业务触发 RocketMQ 时报：
\`\`\`
connect to 172.16.0.3:10911 failed  ←  完全不可达
BrokersSent: [broker-a, broker-a, broker-a]
\`\`\`

根因：install.sh 用 \`hostname -I | awk '{print $1}'\` 获取 brokerIP1。在有多个 Docker bridge / 多网卡的宿主上，第一项可能是 172.16.0.x 这种仅属于某个 bridge 内部的地址，jeepay-net 内的业务容器完全连不上。

## Summary
- brokerIP1 默认改为容器名 \`rocketmq-broker\`，靠 Docker 内置 DNS 在 jeepay-net 内解析。不再依赖 hostname -I。
- 保留 \`brokerIP1=xxx\` 环境变量 override 能力（外部消费者场景）。
- test_install_rocketmq.sh 的断言同步调整。

## Test plan
- [x] 本地 test_*.sh 三条 PASS。
- [x] 远端（Anolis OS）全新安装：broker.conf 中 brokerIP1=rocketmq-broker；broker 启动 "boot success, rocketmq-broker:10911"；jeepaymanager 能解析并 TCP 连通 rocketmq-broker:10911；[8] 自检全绿。
- [ ] PR 触发的 CI 两个 job 全绿。