### PR TITLE
fix(compose): Docker Compose 的 broker.conf 也用容器名作 brokerIP1

### DIFF
--- a/docker/rocketmq/broker/conf/broker.conf
+++ b/docker/rocketmq/broker/conf/broker.conf
@@ -5,7 +5,10 @@ deleteWhen=04
 fileReservedTime=48
 brokerRole=ASYNC_MASTER
 flushDiskType=ASYNC_FLUSH
-# Docker Compose 场景下让 Broker 直接上报容器网络地址，避免模板占位符污染运行配置
+# Docker Compose 场景下统一用容器名作 brokerIP1：jeepay 业务都在同一 compose network 内，
+# 通过 Docker 内置 DNS 按 service name 解析最稳，不依赖 compose 的 ipam 静态 IP；
+# 与 Shell 脚本部署（docs/install/install.sh）的默认行为保持一致。
+brokerIP1=rocketmq-broker
 namesrvAddr=rocketmq-namesrv:9876
 autoCreateTopicEnable=true
 autoCreateSubscriptionGroup=true


### PR DESCRIPTION
## 背景
上一条 PR 修的是 Shell 部署路径（install.sh + broker.conf.template）。Compose 部署走的是另一份静态文件 \`docker/rocketmq/broker/conf/broker.conf\`，原来没设 brokerIP1，依赖 broker 自动探测容器 IP + docker-compose.yml 里钉的静态 IP 兜底——哪天改 ipam 就会踩坑，和 Shell 路径之前暴露的 \`connect to 172.16.0.3:10911 failed\` 同构。

## Summary
给 Compose 的 broker.conf 显式加 \`brokerIP1=rocketmq-broker\`（compose service name）。与 Shell 路径默认行为一致。

## Test plan
- [x] 本地 test_*.sh PASS。
- [ ] PR 触发的 CI 两个 job 全绿。
- 真实 \`docker compose up -d\` 端到端由 @jeequan 在 Compose 开发环境上验证（本次未跑，因为 226 测试服务器一直用的 Shell 部署路径）。