### PR TITLE
fix(nginx): 补齐 WebSocket 反代必需的 HTTP/1.1 + 长超时

### DIFF
--- a/docs/deploy/shell.md
+++ b/docs/deploy/shell.md
@@ -119,12 +119,20 @@ server {
     ssl_certificate_key /etc/ssl/jeepay/pay.key;
 
     location / {
+        proxy_pass http://127.0.0.1:19216;
+        proxy_http_version 1.1;                           # WebSocket 必须（默认 1.0 会让 WS 提前断开）
+
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;   # ← 必须
+        proxy_set_header X-Forwarded-Proto $scheme;       # 必须，否则 Spring Boot 拼 http:// 回调
         proxy_set_header X-Forwarded-Port  $server_port;
-        proxy_pass http://127.0.0.1:19216;
+
+        # WebSocket（商户端支付测试 / 收银台订单状态推送用）
+        proxy_set_header Upgrade   $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout  3600s;
+        proxy_send_timeout  3600s;
     }
 }
 # admin / mch 域名同构，仅 proxy_pass 换为 19217 / 19218
@@ -153,6 +161,7 @@ server {
 ### 反代注意事项
 
 - 外层反代务必传 `X-Forwarded-Proto $scheme`；否则 Spring Boot 会把回调 URL 拼成 `http://`，支付平台回跳失败。
+- **WebSocket 必须开 `proxy_http_version 1.1` + Upgrade/Connection 头 + 长 `proxy_read_timeout`**。商户端支付测试页通过 `ws://mch.../api/anon/ws/payOrder/...` 订阅订单状态；缺任一项会导致握手显示 `101 Switching Protocols` 但后续消息收不到。
 - 第三方支付平台后台填的 **异步通知 URL / 回跳 URL** 必须用公网域名（`https://pay.example.com/api/pay/...`）而不是 `http://<内网 IP>:19216`。
 - 外层 nginx 若开启 `gzip`，注意排除 SSE / WebSocket（`text/event-stream`）。
 - 修改 `nginx.conf` 后：`docker exec nginx118 nginx -s reload`。

--- a/docs/install/include/nginx.conf
+++ b/docs/install/include/nginx.conf
@@ -39,9 +39,13 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-Port $server_port;
             proxy_pass http://localhost:9217;
-            # 启用支持websocket连接
+            # WebSocket 支持：HTTP/1.1 是 Upgrade 协议的前置条件（默认是 1.0 会提前断开）；
+            # 订单状态 / 长连接推送场景下必须把 proxy_read/send_timeout 放大到小时级。
+            proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
         }
     }
 
@@ -70,9 +74,13 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-Port $server_port;
             proxy_pass http://localhost:9218;
-            # 启用支持websocket连接
+            # WebSocket 支持：商户端支付测试页通过 ws://.../api/anon/ws/payOrder/...
+            # 订阅订单状态变化，必须开 HTTP/1.1 + 长超时。
+            proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
         }
     }
 
@@ -90,6 +98,12 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-Port $server_port;
             proxy_pass http://localhost:9216;
+            # WebSocket 支持：收银台轮询订单状态可能走 WS；保持 HTTP/1.1 + 长超时。
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
         }
     }
 


### PR DESCRIPTION
## 背景
商户端支付测试页 ws://.../api/anon/ws/payOrder/... 订阅订单状态，握手返回 101 但支付成功后前端收不到推送。

## 根因
内层 nginx.conf 三个 server 虽设了 Upgrade/Connection 头，但缺：
1. \`proxy_http_version 1.1\` — HTTP/1.0 下 Connection: close 隐式行为会关 WS
2. \`proxy_read_timeout 3600s\` — 默认 60s 长连接必断

## Summary
- 内层 nginx.conf 三个 server 统一补齐三行（nginx -t OK）
- docs/deploy/shell.md 外层反代示例同步补 + WS 专项注释

## Test plan
- [x] nginx -t 语法通过
- [x] test_*.sh PASS
- [ ] PR CI 绿
- 真实 WS 验证：部署后用户在商户端发起支付测试 → 前端收到成功推送，由 @jeequan 验证