### PR TITLE
fix(install): install.sh 在 dash/POSIX sh 下执行也不会挂

### DIFF
--- a/docs/deploy/shell.md
+++ b/docs/deploy/shell.md
@@ -6,12 +6,12 @@
 
 **CentOS / Anolis**
 ```bash
-yum install -y wget curl && wget -O install.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/install.sh && sh install.sh
+yum install -y wget curl && wget -O install.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/install.sh && bash install.sh
 ```
 
 **Ubuntu / Debian**
 ```bash
-apt update && apt-get -y install wget curl git docker.io && wget -O install.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/install.sh && sh install.sh
+apt update && apt-get -y install wget curl git docker.io && wget -O install.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/install.sh && bash install.sh
 ```
 
 脚本会自动识别你的系统、装齐依赖、拉镜像、起 8 个容器、跑部署自检。**默认**：
@@ -34,7 +34,7 @@ apt update && apt-get -y install wget curl git docker.io && wget -O install.sh h
 **卸载**：
 
 ```bash
-wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh && sh uninstall.sh
+wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh && bash uninstall.sh
 ```
 
 ---
@@ -171,7 +171,7 @@ server {
 **推荐（一条命令）**：
 
 ```bash
-wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh && sh uninstall.sh
+wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh && bash uninstall.sh
 ```
 
 脚本自动从跑着的 `mysql8` 容器数据卷反推 `rootDir`，打印确认后再删容器、网络、整个 `rootDir`。
@@ -179,7 +179,7 @@ wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/un
 若 jeepay 容器已全部被手工删除、自动识别不到：
 
 ```bash
-rootDir=/jeepayhomes sh uninstall.sh
+rootDir=/jeepayhomes bash uninstall.sh
 ```
 
 ## 高级覆盖项
@@ -226,7 +226,7 @@ export nginxImage=nginx:1.18.0
 export managerImage=jeepay/jeepay-manager:3.2.0
 export merchantImage=jeepay/jeepay-merchant:3.2.0
 export paymentImage=jeepay/jeepay-payment:3.2.0
-sh install.sh
+bash install.sh
 ```
 
 ## RocketMQ Broker 启动失败

--- a/docs/install/install.sh
+++ b/docs/install/install.sh
@@ -1,5 +1,18 @@
-#! /bin/sh
+#!/usr/bin/env bash
 ## 一键启动jeepay服务，包含mysqlDB/RocketMQ/redis/javaservice/nginx   .Power by terrfly
+## 本脚本使用 bash 专有特性（process substitution / [[ ]] / /dev/tcp），不兼容
+## POSIX sh（Ubuntu/Debian 下 /bin/sh 是 dash）。如果用户习惯性 sh install.sh 执行，
+## 下面这段会自动转交给 bash 重跑，避免出现 "未预期的符号 >" 之类语法错误。
+if [ -z "${BASH_VERSION:-}" ]; then
+    if command -v bash >/dev/null 2>&1; then
+        exec bash "$0" "$@"
+    fi
+    echo 'ERROR: install.sh 需要 bash 运行（脚本使用了 process substitution / /dev/tcp 等 bash 特性）。'
+    echo '       请在系统上安装 bash 后重试，例如：'
+    echo '         Ubuntu / Debian : apt-get install -y bash  然后  bash install.sh'
+    echo '         CentOS / Anolis : 默认已安装 bash，直接 bash install.sh'
+    exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # 命令行参数解析（放在 root 校验之前，便于非 root 也能 --help）
@@ -7,7 +20,7 @@
 AUTO_YES=0
 show_usage() {
     cat <<EOF
-用法: sh install.sh [选项]
+用法: bash install.sh [选项]
 
 选项:
   -y, --yes    自动确认所有 yes/no 提示，适合自动化 / CI 场景。
@@ -844,7 +857,7 @@ cat <<SUMMARY
    docker ps                                查看 8 个容器状态
    docker logs jeepaymanager --tail 100     查看某个服务日志
    wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh \\
-     && sh uninstall.sh                     一键卸载（自动识别 rootDir）
+     && bash uninstall.sh                   一键卸载（自动识别 rootDir）
 ============================================================
 SUMMARY
 


### PR DESCRIPTION
## 背景
客户在新 Ubuntu 机器 \`sh install.sh\` 报错：
\`\`\`
install.sh:行42: 未预期的符号 '>' 附近有语法错误
install.sh:行42: 'exec > >(tee -a "$INSTALL_LOG_FILE") 2>&1'
\`\`\`
Ubuntu/Debian 下 /bin/sh = dash，不支持 bash 的 process substitution。

## Summary
- shebang 改为 \`#!/usr/bin/env bash\`。
- 加自动转交保护：\`BASH_VERSION\` 为空时 \`exec bash "$0" "$@"\`。
- 文档 + show_usage 统一推荐 \`bash install.sh\` 而非 \`sh install.sh\`。
- uninstall.sh 无 bash-only 特性，不改。

## Test plan
- [x] bash -n OK；test_*.sh 三条 PASS。
- [x] \`dash install.sh --help\` 自动转交 bash 成功。
- [x] \`bash install.sh --help\` 正常。
- [ ] PR CI 绿。
- 客户在 Ubuntu 机器重跑 \`bash install.sh -y\`（或即使 \`sh install.sh -y\` 也会自动转交）验证全流程。