### PR TITLE
docs: 再次精简 README 与部署文档，按主题拆分

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,12 @@
 # 目录
 
 - [项目简介](#项目简介)
-- [为什么选择 Jeepay](#为什么选择-jeepay)
-- [适用场景](#适用场景)
+- [Jeepay 适合谁](#jeepay-适合谁)
 - [官方托管服务（计全付）](#官方托管服务计全付)
-- [系统能力概览](#系统能力概览)
-- [快速开始](#快速开始)
 - [部署方式](#部署方式)
 - [系统架构](#系统架构)
 - [核心技术栈](#核心技术栈)
 - [文档与资源](#文档与资源)
-- [在线体验](#在线体验)
-- [版本与兼容性说明](#版本与兼容性说明)
 - [贡献与协作](#贡献与协作)
 - [更多支持](#更多支持)
 
@@ -70,41 +65,22 @@
 
 # 项目简介
 
-Jeepay 是一套面向互联网企业的开源支付系统，支持：
+Jeepay 是一套面向互联网企业的开源支付系统，支持 **普通商户模式** / **多渠道服务商模式** / **聚合码支付** / **多商户多应用接入**。已对接微信支付、支付宝、云闪付等主流渠道。
 
-- **普通商户模式**
-- **多渠道服务商模式**
-- **聚合码支付**
-- **多商户、多应用接入**
+后端 `Spring Boot 3.3.7` + `JDK 17` + `Spring Security`，前端 `Ant Design Vue`，MQ 支持 `RocketMQ` / `ActiveMQ` / `RabbitMQ`。
 
-当前已对接微信支付、支付宝、云闪付等主流渠道；后端 `Spring Boot 3.3.7` + `JDK 17`，前端 `Ant Design Vue`，权限体系 `Spring Security`。
-
-适用于支付能力平台化、商户系统建设、支付中台建设以及聚合支付业务的二次开发。
+适合自建聚合支付平台、SaaS 支付中台、多商户支付系统以及电商 / 零售 / 本地生活 / 数字内容等业务的支付接入与二次开发。
 
 ---
 
-# 为什么选择 Jeepay
+# Jeepay 适合谁
 
-- **支付能力完整**：覆盖下单、退款、通知、分账扩展、渠道管理等常见支付能力
-- **模式灵活**：同时支持普通商户与服务商模式
-- **多渠道兼容**：已具备微信、支付宝、云闪付等主流渠道接入能力
-- **架构清晰**：后端分层明确，前后端分离，适合持续迭代和二开
-- **接入效率高**：标准化 HTTP 接口 + 多语言 SDK，业务系统接入成本低
-- **可运维性好**：支持 Docker、脚本部署、分布式场景和 MQ 通知机制
-- **支付经验沉淀**：由原 `XxPay` 团队持续开发维护，具备多年实战经验
+- 想**独立掌控**支付流程、商户体系、渠道配置、回调通知，不想被托管服务绑定
+- 需要**服务商模式**管理多家商户、多家渠道的平台方
+- 计划长期**二次开发**，希望起点是一套架构清晰、代码分层明确、文档完备的开源系统
+- 需要 Docker / Shell 一键部署、分布式、多 MQ 可切换的**可运维**支付底座
 
----
-
-# 适用场景
-
-- 自建聚合支付平台
-- 多商户支付系统
-- SaaS 平台支付中台
-- 电商、零售、本地生活、数字内容等业务的支付接入
-- 服务商模式下的渠道统一管理与商户统一接入
-- 需要独立掌控支付流程、商户管理、渠道配置和回调通知的项目
-
-如果你希望快速搭建一套可控、可扩展、可二开的支付系统，Jeepay 是比较合适的基础底座。
+由原 `XxPay` 团队持续开发维护，多年支付实战沉淀。
 
 ---
 
@@ -121,63 +97,16 @@ Jeepay 是一套面向互联网企业的开源支付系统，支持：
 
 ---
 
-# 系统能力概览
-
-- **支付渠道**：微信支付（`V2`/`V3`、服务商 / 普通商户）、支付宝（`RSA`/`RSA2`、服务商 / 普通商户）、云闪付
-- **平台能力**：多商户管理、多应用接入、聚合码支付、订单管理、渠道参数配置、商户通知与回调、支付异步通知、权限与账号管理、运营平台与商户平台双端
-- **工程能力**：前后端分离、分布式部署、MQ 通知（RocketMQ / ActiveMQ / RabbitMQ）、Docker 部署与脚本化安装、可二次开发
-
----
-
-# 快速开始
-
-## 环境要求
-
-| 组件 | 要求 |
-|---|---|
-| JDK | 17 |
-| Maven | 建议 3.8+ |
-| MySQL | 5.7.x / 8.0+ |
-| Redis | 3.2.8+ |
-| MQ | RocketMQ（默认）/ ActiveMQ / RabbitMQ（按需启用） |
-| Node.js | 前端工程按 `jeepay-ui` 要求准备 |
-
-## 代码获取
-
-```bash
-git clone https://github.com/jeequan/jeepay.git
-git clone https://github.com/jeequan/jeepay-ui.git
-```
-
-## 首次启动流程
-
-1. **准备数据库与缓存**：创建 MySQL 数据库并导入 `docs/sql/init.sql`；准备 Redis（异步通知增强可按需启用 MQ）。
-2. **准备配置文件**：修改 `conf/manager/application.yml`、`conf/merchant/application.yml`、`conf/payment/application.yml`，填写 MySQL / Redis / 服务端口 / 支付渠道基础参数。
-3. **编译后端**：`mvn clean package -DskipTests`
-4. **启动核心服务**：
-   | 模块 | 说明 | 默认端口 |
-   |---|---|---|
-   | `jeepay-payment` | 支付网关 | `9216` |
-   | `jeepay-manager` | 运营平台服务端 | `9217` |
-   | `jeepay-merchant` | 商户系统服务端 | `9218` |
-5. **启动前端**：参考 <https://github.com/jeequan/jeepay-ui>
-
----
-
 # 部署方式
 
-| 方式 | 适用场景 | 详细说明 |
+| 方式 | 适用场景 | 跳转 |
 |---|---|---|
-| 宝塔面板一键安装 | 有宝塔面板（≥ 9.2.0），追求图形化操作 | 面板 Docker 应用内搜索 `jeepay`，或看 [教程](https://doc.jeequan.com/#/integrate/open/dev/108) |
-| Shell 脚本一键安装 | 干净的 CentOS / Anolis / Ubuntu 服务器，希望一条命令拉起 | [docs/deploy/shell.md](docs/deploy/shell.md) |
-| 自助源码部署 | 需要二次开发 / 接入内部基础设施的团队 | 自行准备 MySQL / Redis / MQ，按环境调整 `conf/` 后 Maven 打包部署 |
-| Docker Compose 部署 | 本地或测试环境快速起完整集群（含前端） | [docs/deploy/compose.md](docs/deploy/compose.md) |
+| **Shell 脚本一键安装** | 干净的 CentOS / Anolis / Ubuntu / Debian 服务器 | [docs/deploy/shell.md](docs/deploy/shell.md) |
+| **Docker Compose 部署** | 本地 / 测试环境起完整集群（含前端） | [docs/deploy/compose.md](docs/deploy/compose.md) |
+| 宝塔面板一键安装 | 有宝塔面板（≥ 9.2.0） | 面板 Docker 应用内搜索 `jeepay`，或看 [教程](https://doc.jeequan.com/#/integrate/open/dev/108) |
+| 自助源码部署 | 对接内部基础设施的团队 | 自备 MySQL / Redis / MQ，按环境调整 `conf/` 后 Maven 打包部署 |
 
-> **国内镜像来源**：Shell 脚本与 Docker Compose 的默认镜像都指向 **华为云 SWR 公开仓库**（`swr.cn-south-1.myhuaweicloud.com/jeepay/*`），由计全官方维护，公网匿名可拉，不依赖 Docker Hub，**无需登录也不需要配置加速器**。
->
-> **架构提示**：x86_64 宿主直接一条命令；ARM64 / Apple Silicon 宿主需先开启 amd64 仿真（RocketMQ 上游仅发布 amd64），细节见 [docs/deploy/shell.md](docs/deploy/shell.md#架构前提)。
->
-> 部署过程中碰到问题，优先看 [docs/deploy/troubleshooting.md](docs/deploy/troubleshooting.md)。
+> 默认镜像指向**华为云 SWR 公开仓库**，国内零配置直达，不依赖 Docker Hub。部署后需域名 + HTTPS 见 [docs/deploy/https.md](docs/deploy/https.md)，出问题优先看 [docs/deploy/troubleshooting.md](docs/deploy/troubleshooting.md)。
 
 ---
 
@@ -221,14 +150,17 @@ git clone https://github.com/jeequan/jeepay-ui.git
 - 接口文档：<https://doc.jeequan.com/#/integrate/open/api/81>
 - 常见问题：<https://doc.jeequan.com/#/integrate/open/dev/107>
 
-## 本仓库拆分文档
+## 本仓库文档
 
-- 部署详解（Shell 脚本）：[docs/deploy/shell.md](docs/deploy/shell.md)
-- 部署详解（Docker Compose）：[docs/deploy/compose.md](docs/deploy/compose.md)
-- 部署常见问题：[docs/deploy/troubleshooting.md](docs/deploy/troubleshooting.md)
+- 部署 — Shell 脚本：[docs/deploy/shell.md](docs/deploy/shell.md)
+- 部署 — Docker Compose：[docs/deploy/compose.md](docs/deploy/compose.md)
+- 部署 — 域名 + HTTPS：[docs/deploy/https.md](docs/deploy/https.md)
+- 部署 — 常见问题排查：[docs/deploy/troubleshooting.md](docs/deploy/troubleshooting.md)
+- 镜像发布（维护者）：[docs/deploy/publish.md](docs/deploy/publish.md)
 - 功能与接口市场：[docs/features.md](docs/features.md)
-- 项目结构与仓库关系：[docs/project-structure.md](docs/project-structure.md)
+- 项目结构：[docs/project-structure.md](docs/project-structure.md)
 - 系统截图：[docs/screenshots.md](docs/screenshots.md)
+- 贡献指南：[CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## SDK 资源
 
@@ -244,37 +176,11 @@ Jeepay 已提供 Java、Python SDK，以及 PHP 对接 Demo：
 
 ---
 
-# 在线体验
-
-- 支付流程体验：<https://www.jeequan.com/demo/jeepay_cashier.html>
-- 管理平台 / 商户系统演示：<https://www.jeequan.com/doc/detail_84.html>
-
----
-
-# 版本与兼容性说明
-
-- 当前项目采用 `Spring Boot 3.3.7`，要求 `JDK 17`
-- 数据库建议使用 `MySQL 5.7.x` 或 `8.0+`，Redis 建议 `3.2.8+`
-- MQ 为可选增强组件，按业务场景选择启用
-- 前端请同步使用对应版本的 `jeepay-ui`
-- SDK 对接优先使用官方 SDK 或示例代码
-
----
-
 # 贡献与协作
 
-欢迎通过以下方式参与项目共建：
-
-- 提交 Issue 反馈问题
-- 提交 Pull Request 改进功能或文档
-- 完善渠道对接能力
-- 补充部署文档、二开文档和示例代码
-
-协作建议：
-
-- 提交前确保核心功能可运行
-- 接口 / 配置项 / 数据库变更请同步更新文档与 SQL 脚本
-- 建议聚焦单一主题，便于评审与合并
+- 分支模型、commit 规范、PR 流程、测试要求：见 [CONTRIBUTING.md](CONTRIBUTING.md)
+- 反馈问题 / 提交 PR / 完善渠道对接 / 补充文档，都欢迎
+- 在线体验：[支付流程](https://www.jeequan.com/demo/jeepay_cashier.html) · [管理平台演示](https://www.jeequan.com/doc/detail_84.html)
 
 ---
 

--- a/docs/deploy/compose.md
+++ b/docs/deploy/compose.md
@@ -1,218 +1,63 @@
 # Docker Compose 部署
 
-适合希望通过容器快速拉起完整开发 / 测试环境的场景。
+适合本地 / 测试环境拉起完整集群（含前端）。
 
-> **国内用户零配置直达。** `docker-compose.yml` 中 MySQL / Redis / RocketMQ 默认镜像、以及 3 个 jeepay 应用 Dockerfile 的 `ARG BASE_IMAGE`（`eclipse-temurin:17-jre`）都已指向 **华为云 SWR 公开仓库**（`swr.cn-south-1.myhuaweicloud.com/jeepay/*`），由计全官方维护，**公网匿名可拉**，不依赖 Docker Hub，无需加速器。下述"国内镜像加速"章节仅在你主动把镜像改回 Docker Hub 或使用其他第三方镜像时才需要。
+## 目录约定
 
-## 目录要求
-
-默认约定：
-
-```text
+```
 jeepay-open/
 ├── jeepay/
 └── jeepay-ui/
 ```
 
-如果你的前端目录不在 `jeepay` 同级目录，可在 `jeepay/.env` 中覆盖 `UI_BASE_DIR`；可参考根目录的 `.env.example`。
+前端不在 jeepay 同级时，可在 `jeepay/.env` 覆盖 `UI_BASE_DIR`（参考 `.env.example`）。
 
-## 构建前准备
-
-### 1. 配置 Docker 国内镜像加速（仅在不走 SWR 时需要）
-
-> 默认镜像都走华为云 SWR 公开仓库，**直接拉即可跳过本节**。只有在你覆盖为 Docker Hub 上游镜像，或者 Compose 文件里某些非 jeepay 维护的镜像仍然来自 Docker Hub 时，才需要配置下面的加速源。
-
-国内网络拉取 Docker Hub 镜像较慢或被墙，建议配置多个镜像加速源（单个源随时可能失效，Docker 会自动 fallback）。
-
-Docker daemon 配置示例：
-
-```json
-{
-  "registry-mirrors": [
-    "https://docker.1ms.run",
-    "https://docker.m.daocloud.io",
-    "https://docker.xuanyuan.me",
-    "https://hub.rat.dev",
-    "https://docker.1panel.live"
-  ]
-}
-```
-
-配置位置：
-
-- **Linux**：`/etc/docker/daemon.json`，修改后执行 `sudo systemctl restart docker`
-- **Docker Desktop（macOS / Windows）**：Settings → Docker Engine，写入上述 JSON 后点击 Apply & Restart
-
-验证是否生效：
+## 启动
 
 ```bash
-docker info | grep -A 5 "Registry Mirrors"
+cd jeepay
+mvn clean package -DskipTests          # 编译后端 JAR
+
+docker compose up -d --build           # 首次：编译镜像 + 启动
+docker compose up -d                   # 后续：跳过编译
+docker compose restart payment         # 重启某个服务
 ```
 
-### 2. 编译后端 JAR
+**默认镜像**指向华为云 SWR 公开仓库（与 Shell 部署一致），国内零配置直达。
 
-在 `jeepay` 根目录执行：
+## 暴露端口
 
-```bash
-mvn clean package -DskipTests
-```
-
-生成的 JAR 位于：
-
-- `jeepay-payment/target/jeepay-payment.jar`
-- `jeepay-manager/target/jeepay-manager.jar`
-- `jeepay-merchant/target/jeepay-merchant.jar`
-
-### 3. 准备前端代码
-
-确保 `jeepay-ui` 仓库已拉取到本地，且目录结构满足上面的要求。
-
-## 启动方式
-
-```bash
-# 首次启动（编译镜像 + 启动）
-docker compose up -d --build
-
-# 后续启动（跳过编译）
-docker compose up -d
-
-# 仅重新编译后端服务
-docker compose build payment manager merchant
-
-# 重启某个服务
-docker compose restart payment
-```
-
-## 启动前校验
-
-```bash
-docker compose config
-```
-
-## 默认暴露端口
-
-| 组件 | 端口 | 说明 |
-|---|---|---|
-| MySQL | `13306` | 映射宿主机 13306，避免与本地 MySQL 冲突 |
-| Redis | `6380` | |
-| RocketMQ NameServer | `9876` | |
-| RocketMQ Broker | `10909` / `10911` / `10912` | |
-| payment | `9216` | 支付网关 |
-| manager | `9217` | 运营平台后端 |
-| merchant | `9218` | 商户系统后端 |
-| manager UI | `9227` | 运营平台前端 |
-| merchant UI | `9228` | 商户系统前端 |
-| cashier UI | `9226` | 收银台前端 |
+| 组件 | 端口 |
+|---|---|
+| MySQL | `13306`（避开宿主 3306） |
+| Redis | `6380` |
+| RocketMQ | `9876` / `10909` / `10911` / `10912` |
+| payment / manager / merchant | `9216` / `9217` / `9218` |
+| 前端 | manager `9227` / merchant `9228` / cashier `9226` |
 
 ## 默认账号
 
-| 平台 | 地址 | 用户名 | 密码 | 来源 |
-|---|---|---|---|---|
-| 运营平台 | http://localhost:9227 | `jeepay` | `jeepay123` | `docs/sql/init.sql` 初始化的超管账号 |
-| 商户系统 | http://localhost:9228 | 运营平台创建的商户用户 | `jeepay666` | 运营平台新建商户时的默认密码（`CS.DEFAULT_PWD`），首次登录后建议立即修改 |
+- 运营平台 `http://localhost:9227`：`jeepay` / `jeepay123`
+- 商户系统 `http://localhost:9228`：需运营平台创建商户用户（默认密码 `jeepay666`）
 
-> 商户系统没有内置账号，需先用超管登录运营平台，创建商户及其登录用户，再用这个商户用户登录 9228 的商户平台。
+## 常用命令
 
-## 核心组件版本
-
-| 组件 | 版本 | 说明 |
-|---|---|---|
-| RocketMQ Server | `5.3.1` | NameServer + Broker |
-| rocketmq-spring-boot-starter | `2.3.5` | Spring Boot 集成，内置 client 5.3.2 |
-| MySQL | `8` | |
-| Redis | `6.2.14` | |
-| Java 基础镜像 | `eclipse-temurin:17-jre` | openjdk 官方镜像已停止维护 |
+```bash
+docker compose ps
+docker compose logs -f --tail=100 payment manager merchant
+docker compose config                  # 启动前变量 / 语法校验
+docker compose down                    # 停止 + 清网络（卷保留）
+docker compose down -v                 # 连同卷一起删
+```
 
 ## 配置说明
 
-- Compose 默认使用 **RocketMQ** 作为消息队列，已配置 `rocketmq-namesrv` 与 `rocketmq-broker`。
-- `conf/payment`、`conf/manager`、`conf/merchant` 已默认切换为 `rocketMQ`，MySQL / Redis 主机名配置为容器内网名 `mysql`、`redis`。
-- MySQL 映射为 `13306:3306`，避免与宿主机本地 MySQL 冲突；容器内部服务仍通过 `mysql:3306` 通信。
-- Java 服务的配置文件通过 volume 挂载，修改 `conf/` 目录下的 yml 后重启对应服务即可生效。
-- `ui-payment` / `ui-manager` / `ui-merchant` 依赖后端 `payment` / `manager` / `merchant` 的健康检查结果；如单独启动 UI，Compose 会先等待对应 Java 服务进入 `healthy`。
-- 如需回退到 ActiveMQ 或切换 RabbitMQ，需同时调整 `docker-compose.yml` 与 `conf/*.yml`。
+- 默认 MQ = RocketMQ；`conf/payment|manager|merchant/application.yml` 已切到 `rocketMQ`。
+- 容器内 MySQL / Redis 主机名 = `mysql` / `redis`（compose 已配 network alias）。
+- 改 `conf/*.yml` 后 `docker compose restart <service>` 即可。
+- 要回到 ActiveMQ / RabbitMQ，需同时改 `docker-compose.yml` 和 `conf/*.yml`。
 
-## 启动后验证
+---
 
-```bash
-# 查看所有容器状态
-docker compose ps
-
-# 查看核心服务日志
-docker compose logs --tail=100 payment manager merchant rocketmq-namesrv rocketmq-broker
-
-# 确认 RocketMQ Broker 启动成功（应看到 "boot success"）
-docker logs jeepay-rocketmq-broker 2>&1 | grep "boot success"
-```
-
-## 镜像发布（维护者流程，终端用户跳过）
-
-> 以下章节仅面向 **维护者 / 二开团队**，用于向自己的镜像仓库推送构建好的 jeepay 镜像。**终端用户请忽略本节**，直接用仓库默认的华为云 SWR 公开镜像即可。
-
-### 发布到 Docker Hub
-
-先执行一次 `docker login`，然后在 `jeepay` 根目录运行：
-
-```bash
-DOCKERHUB_NAMESPACE=<你的 Docker Hub 用户名或组织> \
-IMAGE_TAG=3.2.0 \
-PUSH_LATEST=true \
-sh docker/publish-dockerhub.sh
-```
-
-参数：
-
-- `DOCKERHUB_NAMESPACE`：必填，推送目标命名空间。
-- `IMAGE_TAG`：镜像版本号，默认 `latest`。
-- `PUSH_LATEST=true`：当 `IMAGE_TAG` 不是 `latest` 时，额外推送一份 `latest` 标签。
-- `SKIP_MAVEN=true`：如 JAR 已提前打包，可跳过 `mvn clean package -DskipTests`。
-
-脚本会依次构建并推送：
-
-- `<namespace>/jeepay-manager:<tag>`
-- `<namespace>/jeepay-merchant:<tag>`
-- `<namespace>/jeepay-payment:<tag>`
-
-### 发布到华为云 SWR（统一 tag 自动适配 amd64 / arm64）
-
-先执行一次 `docker login swr.cn-south-1.myhuaweicloud.com`，然后：
-
-```bash
-SWR_NAMESPACE=jeepay \
-IMAGE_TAG=3.2.0 \
-PUSH_LATEST=true \
-sh docker/publish-swr.sh
-```
-
-说明：
-
-- `publish-swr.sh` 会分别构建并推送 `amd64`、`arm64` 临时镜像，再创建统一的多架构 tag。
-- 最终用户只需使用 `swr.cn-south-1.myhuaweicloud.com/<namespace>/jeepay-manager:3.2.0`（及 `latest` / 其他两个服务同理）。
-- 如已提前完成 Maven 打包，可加 `SKIP_MAVEN=true`。
-- 如需改区域，可覆盖 `SWR_REGISTRY`，例如 `SWR_REGISTRY=swr.cn-north-4.myhuaweicloud.com`。
-
-### 同步第三方基础镜像到华为云 SWR
-
-为避免国内部署依赖 Docker Hub，可先把 MySQL / Redis / RocketMQ / Nginx / Java 基础镜像同步到 SWR：
-
-```bash
-SWR_NAMESPACE=jeepay \
-sh docker/sync-swr-thirdparty.sh
-```
-
-默认会同步以下镜像：
-
-- `mysql:8`
-- `mysql:8.0.25`
-- `redis:6.2.14`
-- `apache/rocketmq:5.3.1`
-- `nginx:1.18.0`
-- `eclipse-temurin:17-jre`
-
-同步完成后，仓库内默认部署配置会优先使用：
-
-- `swr.cn-south-1.myhuaweicloud.com/jeepay/mysql:*`
-- `swr.cn-south-1.myhuaweicloud.com/jeepay/redis:*`
-- `swr.cn-south-1.myhuaweicloud.com/jeepay/rocketmq:*`
-- `swr.cn-south-1.myhuaweicloud.com/jeepay/nginx:*`
-- `swr.cn-south-1.myhuaweicloud.com/jeepay/eclipse-temurin:17-jre`
+- 出问题排查：[troubleshooting.md](./troubleshooting.md)
+- 推镜像到 Docker Hub / 华为云 SWR（维护者流程）：[publish.md](./publish.md)

--- a/docs/deploy/https.md
+++ b/docs/deploy/https.md
@@ -1,0 +1,88 @@
+# 域名 + HTTPS 反代
+
+jeepay 三个平台的公网接入需要在 19216 / 19217 / 19218 前面再架一层 nginx + SSL。本文给出可直接抄的模板。
+
+## 代码层面已就绪
+
+- 内置 `nginx.conf` 三个 server 都已补 `X-Forwarded-Proto` / `X-Forwarded-Port` / `proxy_http_version 1.1` / WebSocket 头 / 长超时。
+- Spring Boot 已开启 `server.forward-headers-strategy: framework`。
+
+外层反代只要照下面模板写，回跳 URL / WebSocket / 微信支付 H5 redirect 都会自动拼对。
+
+## 推荐拓扑：三个子域名
+
+| 外部域名 | 用途 | 内部回源 |
+|---|---|---|
+| `admin.example.com` | 运营平台 | `http://127.0.0.1:19217` |
+| `mch.example.com` | 商户平台 | `http://127.0.0.1:19218` |
+| `pay.example.com` | 支付网关 + 收银台 | `http://127.0.0.1:19216` |
+
+## 外层 nginx 模板
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name pay.example.com;
+    ssl_certificate     /etc/ssl/jeepay/pay.crt;
+    ssl_certificate_key /etc/ssl/jeepay/pay.key;
+
+    location / {
+        proxy_pass http://127.0.0.1:19216;
+        proxy_http_version 1.1;                         # 必须，否则 WS 会被隐式关闭
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;     # 必须，否则 Spring Boot 拼 http:// 回调
+        proxy_set_header X-Forwarded-Port  $server_port;
+
+        # WebSocket（商户端支付测试 / 收银台订单推送）
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout  3600s;                      # 默认 60s，长连接会静默断
+        proxy_send_timeout  3600s;
+    }
+}
+# admin / mch 域名同构，仅 proxy_pass 换为 19217 / 19218
+```
+
+## 快速申请 Let's Encrypt 证书
+
+```bash
+# 宿主机（不是容器内）
+yum install -y nginx certbot python3-certbot-nginx   # Ubuntu: apt-get -y install ...
+certbot --nginx -d admin.example.com -d mch.example.com -d pay.example.com \
+  --agree-tos -m you@example.com --redirect
+```
+
+`certbot --nginx` 会自动给你上面写的 server 块加 `listen 443 ssl` + cert 路径 + HTTP→HTTPS 301。
+
+## 第三方支付平台回调 URL
+
+去微信 / 支付宝 / 云闪付后台，异步通知 / 回跳 URL 必须填**公网域名**，不要填内网 IP：
+
+```
+https://pay.example.com/api/pay/notify/...
+https://pay.example.com/api/anon/paySuccess?...
+```
+
+## 验证
+
+```bash
+# 握手 101 + Spring Boot 能识别 https
+curl -s -I https://admin.example.com/api/anon/auth/vercode?t=$(date +%s) | head -3
+# 收银台
+curl -s -o /dev/null -w "%{http_code}\n" https://pay.example.com/cashier/index.html
+```
+
+访问 `https://admin.example.com` 登录、`https://mch.example.com` 发起支付测试，浏览器 DevTools Network 里 WS 连接应该能持续收到订单状态推送。
+
+## 防火墙
+
+- 公网必须开：`80` `443`
+- 公网建议关：`19216` / `19217` / `19218`（已通过 80/443 反代提供）
+
+## 不同拓扑的取舍
+
+- **单域名 + 路径前缀**（比如 `https://www.example.com/admin/`）：需要同步改前端 `publicPath` + Spring Boot `context-path`，工作量大，不推荐新手。
+- **只对外暴露收银台**：SaaS / 电商最常用，公网只放 `pay.example.com`，运营 / 商户平台留内网。防火墙只开一个子域对应的 80/443。

--- a/docs/deploy/publish.md
+++ b/docs/deploy/publish.md
@@ -1,0 +1,62 @@
+# 镜像发布（维护者流程）
+
+终端用户**不需要**看本文。仓库默认镜像已指向华为云 SWR 公开仓库，装即用。
+
+本文给计全团队 / 二开团队说明如何把自己构建的 jeepay 镜像推到镜像仓库。
+
+## 发布到 Docker Hub
+
+```bash
+docker login
+
+DOCKERHUB_NAMESPACE=<你的 Docker Hub 用户名或组织> \
+IMAGE_TAG=3.2.0 \
+PUSH_LATEST=true \
+bash docker/publish-dockerhub.sh
+```
+
+参数：
+
+- `DOCKERHUB_NAMESPACE`：必填。
+- `IMAGE_TAG`：版本号，默认 `latest`。
+- `PUSH_LATEST=true`：非 latest tag 时额外补推 latest。
+- `SKIP_MAVEN=true`：JAR 已提前打包时跳过 `mvn package`。
+
+推送产物：
+
+- `<namespace>/jeepay-manager:<tag>`
+- `<namespace>/jeepay-merchant:<tag>`
+- `<namespace>/jeepay-payment:<tag>`
+
+## 发布到华为云 SWR（amd64 + arm64 多架构）
+
+```bash
+docker login swr.cn-south-1.myhuaweicloud.com
+
+SWR_NAMESPACE=jeepay \
+IMAGE_TAG=3.2.0 \
+PUSH_LATEST=true \
+bash docker/publish-swr.sh
+```
+
+- 分别构建并推 `amd64` / `arm64` 临时 tag，再合成统一多架构 tag。
+- 用户最终使用：`swr.cn-south-1.myhuaweicloud.com/<namespace>/jeepay-manager:3.2.0`。
+- 改区域：`SWR_REGISTRY=swr.cn-north-4.myhuaweicloud.com`。
+
+## 同步第三方基础镜像到 SWR
+
+让国内用户完全免 Docker Hub 访问：
+
+```bash
+SWR_NAMESPACE=jeepay bash docker/sync-swr-thirdparty.sh
+```
+
+默认同步：
+
+- `mysql:8` / `mysql:8.0.25`
+- `redis:6.2.14`
+- `apache/rocketmq:5.3.1`
+- `nginx:1.18.0`
+- `eclipse-temurin:17-jre`
+
+同步完成后仓库默认部署配置会优先使用 `swr.cn-south-1.myhuaweicloud.com/jeepay/*`。

--- a/docs/deploy/shell.md
+++ b/docs/deploy/shell.md
@@ -1,7 +1,5 @@
 # Shell 脚本一键安装
 
-## 5 分钟上手
-
 在一台干净的 x86_64 服务器（CentOS / Anolis / Ubuntu / Debian）上，复制粘贴一条命令：
 
 **CentOS / Anolis**
@@ -14,235 +12,68 @@ yum install -y wget curl && wget -O install.sh https://gitee.com/jeequan/jeepay/
 apt update && apt-get -y install wget curl git docker.io && wget -O install.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/install.sh && bash install.sh
 ```
 
-脚本会自动识别你的系统、装齐依赖、拉镜像、起 8 个容器、跑部署自检。**默认**：
+脚本自动：识别发行版、装齐依赖（`wget` / `curl` / `git` / `docker`）、拉镜像、起 8 个容器、跑部署自检。**默认**：
 
 | 项 | 值 |
 |---|---|
 | 安装目录 | `/jeepayhomes` |
 | 镜像来源 | `swr.cn-south-1.myhuaweicloud.com/jeepay/*`（华为云 SWR 公开仓库，免登录） |
-| MQ 方案 | RocketMQ（namesrv + broker） |
-| 源码 ref | `V3.2.7`（与业务镜像 `3.2.0` 完全兼容） |
+| MQ | RocketMQ（namesrv + broker） |
+| 源码 ref | 最新 release tag（与业务镜像完全兼容） |
 
-装完后访问：
+装完访问：
 
 | 平台 | 地址 | 账号 / 密码 |
 |---|---|---|
-| 运营平台 | `http://外网IP:19217` | `jeepay` / `jeepay123` |
-| 商户系统 | `http://外网IP:19218` | 需在运营平台创建商户用户，默认密码 `jeepay666` |
-| 支付网关 / 收银台 | `http://外网IP:19216/cashier/index.html` | — |
+| 运营平台 | `http://<IP>:19217` | `jeepay` / `jeepay123` |
+| 商户系统 | `http://<IP>:19218` | 需在运营平台创建商户用户，默认密码 `jeepay666` |
+| 支付网关 / 收银台 | `http://<IP>:19216/cashier/index.html` | — |
 
-**卸载**：
-
-```bash
-wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh && bash uninstall.sh
-```
-
----
-
-以下章节讲**默认路径之外**的场景：前置依赖细节、自检、端口冲突、HTTPS 反代、高级覆盖项、排障。
-
-## 前置依赖
-
-脚本需要的四个命令，按优先级装齐：
-
-| 命令 | 用途 | 缺失兜底 |
-|---|---|---|
-| `wget` | 下载 `install.sh` 自身、`config.sh`、前端静态资源包 | **必须由一键命令预装**（脚本本身靠 wget 启动） |
-| `curl` | `install.sh` 结束前的部署自检 `[8]` | 缺失只会让自检报 `WARN`，不影响部署本身 |
-| `git` | `git clone` 拉取 jeepay 源码 | `install.sh` 会自动识别 `apt` / `dnf` / `yum` / `apk` 并安装 |
-| `docker` | 启动所有容器 | 同上，Docker daemon 也会自动 start / enable |
-
-CentOS / Anolis 的一键命令只装 `wget curl` 是因为 `git` 和 `docker` 交给脚本；Ubuntu / Debian 的一键命令把四个都装了，是因为脚本在 minimal Ubuntu 镜像上可能先卡在 `wget -O install.sh`。
-
-## 部署后自检
-
-`install.sh` 结束前会自动执行（约 30 秒）：
-
-1. 轮询 `jeepaymanager` / `jeepaymerchant` / `jeepaypayment` 的 `docker healthcheck` 状态（最长 180 秒）；
-2. 探测宿主机 `19216` / `19217` / `19218` 端口的 HTTP 响应；
-3. 调用运营平台 `/api/anon/auth/vercode` 接口（会触发 MySQL + Redis 通路）。
-
-任一步骤不达标会打印 `WARN` 并给排查指引。完整日志落在 `/tmp/jeepay-install-<时间戳>.log`（安装开始时脚本会在第一行打印路径，结束时 summary box 再次列出），失败时先看这个文件。
-
-## 默认开放端口
-
-| 组件 | 端口 | 说明 |
-| --- | --- | --- |
-| MySQL | `3306` | 被占时脚本自动换到 `13306` 之后 |
-| Redis | `6379` | 被占时脚本自动换到 `16379` 之后 |
-| RocketMQ NameServer | `9876` | 被占时脚本退出 |
-| RocketMQ Broker | `10909` / `10911` / `10912` | 被占时脚本退出 |
-| 支付网关 | `19216` | payment 服务 |
-| 运营平台 | `19217` | manager 服务 |
-| 商户平台 | `19218` | merchant 服务 |
-
-## 宿主端口冲突
-
-`install.sh` 在进入 `[1]` 之前会预检以上端口：
-
-- **MySQL / Redis** 被占时 **自动换端口**（3306 → 13306 → 13307…；6379 → 16379 …）并打印 `INFO` 继续部署，无需重跑。容器内仍是标准端口，jeepay 各服务在 `jeepay-net` 内部仍通过 `mysql:3306` / `redis:6379` 通信。
-- **RocketMQ / Nginx** 端口与容器内通信耦合（broker 会广播 `brokerIP1:10911`，nginx 的 `listen` 写进静态配置），**不支持自动换**，命中冲突请先释放占用进程再重跑：
+## 常用命令
 
 ```bash
-ss -lntp | grep -E ':9876|:1091[0-2]|:1921[6-8]'
+# 容器 / 日志 / 资源
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+docker logs -f jeepaymanager --tail 100
+docker stats --no-stream
+
+# 改完 yml / nginx.conf 后重启或重载
+docker restart jeepaymanager jeepaymerchant jeepaypayment
+docker exec nginx118 nginx -t && docker exec nginx118 nginx -s reload
+
+# 完整安装日志（每步输出 + summary box）
+ls -lt /tmp/jeepay-install-*.log | head -1
+
+# MySQL / Redis 直连
+docker exec -it mysql8 mysql -uroot -p'jeepaydb123456' jeepaydb
+docker exec -it redis6 redis-cli
 ```
-
-如果想指定固定 MySQL / Redis 宿主端口（不靠脚本自动挑），见 [高级覆盖项](#高级覆盖项)。
-
-## 配置域名 + HTTPS
-
-脚本内置的 `docs/install/include/nginx.conf` 已经做了三段反代：
-
-- `19217` → 运营平台静态 + `/api/` 反代到 Spring Boot `9217`；
-- `19218` → 商户平台静态 + `/api/` 反代到 Spring Boot `9218`；
-- `19216` → 整体反代到 Spring Boot `9216`（收银台静态资源与支付 API 均由 `jeepay-payment` 自己提供，静态页面路径为 `/cashier/index.html`）。
-
-三个 `server` 块都补了 `X-Forwarded-Proto` / `X-Forwarded-Port` / `X-Forwarded-For`，配合 Spring Boot 侧 `server.forward-headers-strategy: framework`（已默认开启）即可保证外层 HTTPS 反代时，收银台 `return_url` / 支付回调 URL / 微信 H5 `redirect_url` 拼出的协议与 host 始终正确。
-
-### 拓扑一：三个子域名
-
-最简单的部署方式。外层 nginx 申请三张证书，分别把请求反代到内层的 19217 / 19218 / 19216：
-
-| 外部 | 用途 | 内部回源 |
-|---|---|---|
-| `https://admin.example.com` | 运营平台 | `http://127.0.0.1:19217` |
-| `https://mch.example.com` | 商户平台 | `http://127.0.0.1:19218` |
-| `https://pay.example.com` | 支付网关 + 收银台 | `http://127.0.0.1:19216` |
-
-外层 nginx 示例（HTTPS 终结在外层，内层按内部 HTTP 回源）：
-
-```nginx
-server {
-    listen 443 ssl http2;
-    server_name pay.example.com;
-    ssl_certificate     /etc/ssl/jeepay/pay.crt;
-    ssl_certificate_key /etc/ssl/jeepay/pay.key;
-
-    location / {
-        proxy_pass http://127.0.0.1:19216;
-        proxy_http_version 1.1;                           # WebSocket 必须（默认 1.0 会让 WS 提前断开）
-
-        proxy_set_header Host              $host;
-        proxy_set_header X-Real-IP         $remote_addr;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;       # 必须，否则 Spring Boot 拼 http:// 回调
-        proxy_set_header X-Forwarded-Port  $server_port;
-
-        # WebSocket（商户端支付测试 / 收银台订单状态推送用）
-        proxy_set_header Upgrade   $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_read_timeout  3600s;
-        proxy_send_timeout  3600s;
-    }
-}
-# admin / mch 域名同构，仅 proxy_pass 换为 19217 / 19218
-```
-
-收银台联通性验证：`https://pay.example.com/cashier/index.html` 应返回 HTTP 200。
-
-> 实际交易中，客户看到的收银台 URL 不需要手工构造——jeepay API 返回的 `payUrl` 已经是带参数的完整路径（形如 `/cashier/index.html?token=xxx`）。上面的 URL 仅用于部署联通性验证。
-
-### 拓扑二：一个域名 + 路径前缀
-
-只有一个主域名 `https://www.example.com` 把三套前后端塞到子路径。这种拓扑需要同步前端构建时的 `publicPath`（`jeepay-ui` 的 `vue.config.js`）和 Spring Boot 的 `server.servlet.context-path`，否则静态资源 404 / API 404。适合**有前端构建能力**的团队，不建议新手使用。
-
-### 拓扑三：只对外暴露收银台
-
-电商 / SaaS 侧最常见：只把收银台对客户暴露，运营 / 商户平台留在内网 / VPN。
-
-```
-公网域名 https://pay.example.com  →  http://127.0.0.1:19216
-运营平台 http://内网 IP:19217                        （不对公网放行）
-商户平台 http://内网 IP:19218                        （不对公网放行）
-```
-
-对应的防火墙规则只放行 19216。
-
-### 反代注意事项
-
-- 外层反代务必传 `X-Forwarded-Proto $scheme`；否则 Spring Boot 会把回调 URL 拼成 `http://`，支付平台回跳失败。
-- **WebSocket 必须开 `proxy_http_version 1.1` + Upgrade/Connection 头 + 长 `proxy_read_timeout`**。商户端支付测试页通过 `ws://mch.../api/anon/ws/payOrder/...` 订阅订单状态；缺任一项会导致握手显示 `101 Switching Protocols` 但后续消息收不到。
-- 第三方支付平台后台填的 **异步通知 URL / 回跳 URL** 必须用公网域名（`https://pay.example.com/api/pay/...`）而不是 `http://<内网 IP>:19216`。
-- 外层 nginx 若开启 `gzip`，注意排除 SSE / WebSocket（`text/event-stream`）。
-- 修改 `nginx.conf` 后：`docker exec nginx118 nginx -s reload`。
 
 ## 卸载
 
-**推荐（一条命令）**：
-
 ```bash
 wget -O uninstall.sh https://gitee.com/jeequan/jeepay/raw/master/docs/install/uninstall.sh && bash uninstall.sh
 ```
 
-脚本自动从跑着的 `mysql8` 容器数据卷反推 `rootDir`，打印确认后再删容器、网络、整个 `rootDir`。
+脚本自动识别 `rootDir`（从 `mysql8` 容器卷反推），打印确认后删容器 / 网络 / 整个 `rootDir`。若容器已手工清掉，可显式：`rootDir=/jeepayhomes bash uninstall.sh`。
 
-若 jeepay 容器已全部被手工删除、自动识别不到：
+## 高级覆盖项（可选）
 
-```bash
-rootDir=/jeepayhomes bash uninstall.sh
-```
+安装前 `export xxx=yyy`，或在 `docs/install/config.sh` 取消对应注释行即可。
 
-## 高级覆盖项
-
-绝大多数用户用默认值即可。以下变量按需通过环境变量或 [`config.sh`](../install/config.sh)（取消注释）覆盖：
-
-| 变量 | 默认值 | 何时需要改 |
+| 变量 | 默认 | 场景 |
 |---|---|---|
-| `rootDir` | `/jeepayhomes` | 想把部署目录放到其他位置（比如 `/data/jeepay`） |
-| `mysql_pwd` | `jeepaydb123456` | 想改 MySQL root 密码 |
-| `mysqlHostPort` | `3306`（被占时自动换） | 想固定到某个特定端口（不让脚本自动挑） |
-| `redisHostPort` | `6379`（被占时自动换） | 同上 |
-| `mysqlImage` | `swr.../jeepay/mysql:8.0.25` | 切到内网镜像仓库、固定其他版本，或回 Docker Hub |
-| `redisImage` | `swr.../jeepay/redis:6.2.14` | 同上 |
-| `rocketmqImage` | `swr.../jeepay/rocketmq:5.3.1` | 同上；若使用自行构建的原生 arm64 镜像请同时改 `rocketmqPlatform` |
-| `nginxImage` | `swr.../jeepay/nginx:1.18.0` | 同上 |
-| `managerImage` / `merchantImage` / `paymentImage` | `swr.../jeepay/jeepay-*:3.2.0` | 切到自有仓库或其他版本 |
-| `rocketmqPlatform` | `linux/amd64` | 使用原生 arm64 镜像时改 `linux/arm64`（RocketMQ 上游仅发布 amd64） |
-| `jeepayRef` | `V3.2.7` | 想拉其他 release tag 或 master 分支 |
+| `rootDir` | `/jeepayhomes` | 改部署目录 |
+| `mysql_pwd` | `jeepaydb123456` | 改 MySQL root 密码 |
+| `mysqlHostPort` / `redisHostPort` | `3306` / `6379`（被占自动换到 `13306` / `16379`） | 固定到某个端口 |
+| `mysqlImage` / `redisImage` / `rocketmqImage` / `nginxImage` | SWR 官方 | 切内网仓库 / 回 Docker Hub |
+| `managerImage` / `merchantImage` / `paymentImage` | SWR `jeepay-*:3.2.0` | 换自有镜像 / 版本 |
+| `rocketmqPlatform` | `linux/amd64` | 自行构建的 arm64 RocketMQ 镜像时改 `linux/arm64`（上游 rocketmq 不发 arm64） |
+| `brokerIP1` | `rocketmq-broker` | 有外部 RocketMQ 客户端时改真实 IP |
+| `jeepayRef` | 最新 release tag | 临时拉 master 或其他 tag |
 
-命令行参数：
+---
 
-| 参数 | 作用 |
-|---|---|
-| `-y` / `--yes` | 跳过脚本中所有 yes/no 确认，适合 CI / 量产脚本 |
-| `-h` / `--help` | 打印帮助并退出 |
-
-### ARM64 / Apple Silicon 注意
-
-RocketMQ 上游**只发布 `linux/amd64`** 镜像。在 ARM64 宿主上部署需要先启用 amd64 仿真层，否则 `[5]` 会失败：
-
-- Linux ARM64（自建机 / 云厂商 arm 实例）：`docker run --privileged --rm tonistiigi/binfmt --install amd64`
-- macOS Apple Silicon：Docker Desktop 开启 **Use Rosetta for x86_64/amd64 emulation**
-
-其它镜像（mysql / redis / nginx / temurin）SWR 已同步 amd64 + arm64 多架构 manifest，原生运行。
-
-### 切回 Docker Hub 上游镜像示例
-
-```bash
-export mysqlImage=mysql:8.0.25
-export redisImage=redis:6.2.14
-export rocketmqImage=apache/rocketmq:5.3.1
-export nginxImage=nginx:1.18.0
-export managerImage=jeepay/jeepay-manager:3.2.0
-export merchantImage=jeepay/jeepay-merchant:3.2.0
-export paymentImage=jeepay/jeepay-payment:3.2.0
-bash install.sh
-```
-
-## RocketMQ Broker 启动失败
-
-如果安装卡在 `[5]`，脚本会自动输出最近日志并失败退出。优先检查：
-
-1. 服务器架构是否兼容所用的 `rocketmq:5.3.1` 镜像（ARM64 需 amd64 仿真）；
-2. `$rootDir/rocketmq/broker/store` 目录权限是否正常；
-3. `$rootDir/rocketmq/broker/conf/broker.conf` 是否成功挂载（模板写入的 `brokerIP1` 是否为当前服务器 IP）；
-4. `rocketmq-namesrv` 是否已正常启动。
-
-手动排查：
-
-```bash
-docker logs --tail 50 rocketmq-namesrv
-docker logs --tail 100 rocketmq-broker
-# 完整安装日志（安装开始 / 结束都打印了具体路径）
-ls -lt /tmp/jeepay-install-*.log | head -1
-```
+- 出问题排查：[troubleshooting.md](./troubleshooting.md)
+- 域名 + HTTPS 反代：[https.md](./https.md)
+- Docker Compose 部署：[compose.md](./compose.md)

--- a/docs/deploy/troubleshooting.md
+++ b/docs/deploy/troubleshooting.md
@@ -1,31 +1,132 @@
 # 部署常见问题排查
 
-## RocketMQ Broker 启动失败（NullPointerException）
+排障第一步：先看**完整安装日志**（Shell 部署时脚本在开头与 summary box 里都打印了路径）：
 
-如果 Broker 日志中出现 `ScheduleMessageService.configFilePath` 相关 NPE，通常是 Docker named volume 的权限问题。RocketMQ 5.x 镜像以 `rocketmq`（uid=3000）用户运行，而 Docker 创建的 volume 默认 `root` 权限。
+```bash
+ls -lt /tmp/jeepay-install-*.log | head -1
+less $(ls -t /tmp/jeepay-install-*.log | head -1)
+```
 
-`docker-compose.yml` 中已通过 `user: "0:0"` 解决此问题。如果手动部署遇到此问题，可执行：
+## 登录页验证码不出 / 任何 DB 操作报错
+
+99% 是 manager 连不上 MySQL 或 Redis。按下面顺序排查：
+
+```bash
+# 1) 三个应用是否 healthy
+for c in jeepaymanager jeepaymerchant jeepaypayment; do
+  echo -n "$c: "; docker inspect --format '{{.State.Health.Status}}' $c
+done
+
+# 2) manager 实际挂载的 application.yml
+docker exec jeepaymanager grep -nE "url:|host:|password:" /jeepayhomes/service/app/application.yml
+
+# 3) 从 manager 容器内验证 DB / Redis 连通
+docker exec jeepaymanager getent hosts mysql redis
+docker exec jeepaymanager sh -c "timeout 3 bash -c '</dev/tcp/mysql/3306' && echo MySQL_OK"
+docker exec jeepaymanager sh -c "timeout 3 bash -c '</dev/tcp/redis/6379' && echo Redis_OK"
+```
+
+历史坑（V3.2.7 之前的老部署可能遇到）：
+- `application.yml` 里 `host: redis` / `mysql`，但容器名是 `redis6` / `mysql8` → 新版 `install.sh` 已给容器加 `--network-alias`。
+- `password: rootroot`（Compose 默认）与 `mysql_pwd=jeepaydb123456` 不一致 → 新版 `install.sh` 会自动 `sed` 替换。
+
+## 业务触发 RocketMQ 时报 `connect to x.x.x.x:10911 failed`
+
+两个可能原因：
+1. **broker.conf 里 `brokerIP1` 是宿主的某个 Docker bridge 地址**（老版本用 `hostname -I` 挑错了）：
+   ```bash
+   rootDir=$(docker inspect mysql8 --format '{{range .Mounts}}{{if eq .Destination "/var/lib/mysql"}}{{.Source}}{{end}}{{end}}' | sed 's|/mysql/data$||')
+   sed -i 's/^brokerIP1=.*/brokerIP1=rocketmq-broker/' $rootDir/rocketmq/broker/conf/broker.conf
+   docker restart rocketmq-broker
+   ```
+2. **broker 启动好了但 Spring Boot RocketMQ producer 缓存了坏连接**——重启三个业务应用让客户端重新从 nameserver 拉路由：
+   ```bash
+   docker restart jeepaymanager jeepaymerchant jeepaypayment
+   ```
+
+## RocketMQ Broker 启动失败 NullPointerException
+
+Broker 日志出现 `ScheduleMessageService.configFilePath` 相关 NPE，通常是 volume 权限问题。RocketMQ 5.x 镜像以 `rocketmq`（uid=3000）用户运行，而 Docker volume 默认 root 权限：
 
 ```bash
 docker run --rm -u root -v jeepay_rocketmq_broker_store:/data alpine chown -R 3000:3000 /data
 docker run --rm -u root -v jeepay_rocketmq_broker_logs:/data alpine chown -R 3000:3000 /data
 ```
 
-## Apple Silicon（M1/M2/M3）注意事项
+Compose 已通过 `user: "0:0"` 规避；Shell 部署命中需手工修。
 
-RocketMQ 官方镜像仅提供 `linux/amd64` 版本，在 Apple Silicon 上通过 Rosetta 2 模拟运行，启动较慢属于正常现象。请确保 Docker Desktop 已开启 **Use Rosetta for x86_64/amd64 emulation on Apple Silicon**。
+## WebSocket 握手 101 但收不到消息
 
-## 前端镜像构建失败
+商户端支付测试页 `ws://.../api/anon/ws/payOrder/...` 订阅订单状态，握手显示 `101 Switching Protocols` 但后续没数据。外层 nginx 必须配：
 
-优先检查：
+```nginx
+proxy_http_version 1.1;                # 必须，HTTP/1.0 下 Connection: close 隐式生效
+proxy_set_header Upgrade   $http_upgrade;
+proxy_set_header Connection "upgrade";
+proxy_read_timeout  3600s;             # 默认 60s，长连接必断
+proxy_send_timeout  3600s;
+```
 
-- `jeepay-ui` 目录是否存在且在正确位置；
-- Node.js 依赖是否可正常安装（npm 源是否可达）。
+内层 jeepay 内置 nginx 已从 V3.2.7 起全量补齐，外层反代若自己维护需同步修。
 
-## 登录提示"认证服务出现异常"
+## `application.yml` 变成目录而不是文件
 
-检查 `conf/*/application.yml` 中的数据库连接配置是否与 `docker-compose.yml` 中的 MySQL 密码一致。Compose 默认 root 密码为 `rootroot`。
+Spring Boot 容器起来但拿不到配置。原因：某次 `cp` 失败后 `docker run -v <path>:<container>` 把 host 不存在的 path 自动建成目录：
 
-## 镜像拉取失败（403 Forbidden）
+```bash
+docker stop jeepaymanager jeepaymerchant jeepaypayment
+rm -rf $rootDir/service/configs
+bash uninstall.sh        # 或手工重跑 install.sh 的 [6] 步骤
+```
 
-镜像加速源可能失效，建议配置多个加速源（参见 [Docker Compose 部署 — 配置 Docker 国内镜像加速](./compose.md#1-配置-docker-国内镜像加速强烈建议)），Docker 会自动尝试下一个。
+V3.2.8+ 的 `install.sh` 每个 `cp` 都加了返回值 + 文件类型校验，失败会 `exit 1` 明确指引，不再留半成品。
+
+## Apple Silicon（M1/M2/M3）
+
+RocketMQ 官方镜像只发布 `linux/amd64`，在 Apple Silicon 上通过 Rosetta 2 模拟运行，启动略慢属正常。Docker Desktop → Settings → 开启 **Use Rosetta for x86_64/amd64 emulation**。
+
+## 镜像拉取失败（403 / 超时）
+
+默认 SWR 镜像偶尔有地区限制，先确认：
+
+```bash
+docker pull swr.cn-south-1.myhuaweicloud.com/jeepay/mysql:8.0.25
+```
+
+如持续失败，可临时回 Docker Hub 上游（安装前 export）：
+
+```bash
+export mysqlImage=mysql:8.0.25
+export redisImage=redis:6.2.14
+export rocketmqImage=apache/rocketmq:5.3.1
+export nginxImage=nginx:1.18.0
+export managerImage=jeepay/jeepay-manager:3.2.0
+export merchantImage=jeepay/jeepay-merchant:3.2.0
+export paymentImage=jeepay/jeepay-payment:3.2.0
+bash install.sh
+```
+
+## 前端镜像构建失败（Docker Compose 场景）
+
+- `jeepay-ui` 目录是否存在且在 `jeepay` 同级？
+- `UI_BASE_DIR` 是否正确？
+- npm 源是否可达？必要时在 `jeepay-ui` 的 Dockerfile 里切淘宝源。
+
+## 打包排障现场给维护者
+
+```bash
+ts=$(date +%Y%m%d-%H%M%S)
+out=/tmp/jeepay-debug-$ts
+mkdir -p $out
+docker ps -a > $out/docker-ps.txt
+for c in mysql8 redis6 rocketmq-namesrv rocketmq-broker jeepaymanager jeepaymerchant jeepaypayment nginx118; do
+    docker logs --tail 200 $c > $out/log-$c.txt 2>&1
+    docker inspect $c > $out/inspect-$c.json 2>&1
+done
+docker network inspect jeepay-net > $out/network.json 2>&1
+cp $(ls -t /tmp/jeepay-install-*.log | head -1) $out/install.log 2>/dev/null
+tar -czf $out.tar.gz -C /tmp "$(basename $out)"
+echo "已打包到：$out.tar.gz"
+```
+
+把 `.tar.gz` 发维护者，能直接定位。


### PR DESCRIPTION
## Summary
按"门面文档只放最常用，深水区分到独立文件"思路再简化一轮。

| 文件 | 前 | 后 | 变化 |
|---|---|---|---|
| README.md | 299 | 205 | -31% |
| docs/deploy/shell.md | 248 | 79 | -68% |
| docs/deploy/compose.md | 218 | 63 | -71% |
| docs/deploy/troubleshooting.md | 31 | 132 | 吸收 shell.md 移出的排障内容 |
| docs/deploy/https.md | — | 88 | 新增（从 shell.md 搬出） |
| docs/deploy/publish.md | — | 62 | 新增（从 compose.md 搬出） |

## Test plan
- [x] test_*.sh PASS
- [ ] PR CI 绿