### PR TITLE
fix(baota): alpine/git 镜像用真实 tag v2.45.2

### DIFF
--- a/docker-compose.baota.yml
+++ b/docker-compose.baota.yml
@@ -35,7 +35,7 @@ services:
   # - cp -n 铺到共享卷，已存在文件跳过（保护用户编辑）
   # - 最新模板同时刷到 .latest/，升级时 diff 对比
   jeepay-configs:
-    image: ${JEEPAY_CONFIGS_IMAGE:-alpine/git:2.40}
+    image: ${JEEPAY_CONFIGS_IMAGE:-alpine/git:v2.45.2}
     container_name: jeepay-configs
     volumes:
       - ${APP_PATH}/jeepayhomes/:/jeepayhomes

--- a/docs/deploy/baota.md
+++ b/docs/deploy/baota.md
@@ -37,7 +37,7 @@
 | `MANAGER_IMAGE` | `swr.cn-south-1.myhuaweicloud.com/jeepay/jeepay-manager:${VERSION}` |
 | `MERCHANT_IMAGE` | `swr.cn-south-1.myhuaweicloud.com/jeepay/jeepay-merchant:${VERSION}` |
 | `PAYMENT_IMAGE` | `swr.cn-south-1.myhuaweicloud.com/jeepay/jeepay-payment:${VERSION}` |
-| `JEEPAY_CONFIGS_IMAGE` | `alpine/git:2.40`（Docker Hub） |
+| `JEEPAY_CONFIGS_IMAGE` | `alpine/git:v2.45.2`（Docker Hub） |
 
 **切回 Docker Hub 整套示例**：
 


### PR DESCRIPTION
## 背景
宝塔装 jeepay 报 `docker.io/alpine/git:2.40: not found`。
alpine/git 的 tag 格式是 v2.xx.x 或 2.xx.x（带 patch 号），不存在 `2.40` 这种 minor-only tag。

## Fix
`alpine/git:2.40` → `alpine/git:v2.45.2`（Docker Hub 验证该 tag 存在）

## Test
- docker compose config 解析 OK
- test_*.sh PASS