### PR TITLE
fix(baota): jeepay-configs 容器加 entrypoint:[] 清空 alpine/git 默认 git

### DIFF
--- a/docker-compose.baota.yml
+++ b/docker-compose.baota.yml
@@ -37,6 +37,8 @@ services:
   jeepay-configs:
     image: ${JEEPAY_CONFIGS_IMAGE:-alpine/git:v2.45.2}
     container_name: jeepay-configs
+    # alpine/git 的 ENTRYPOINT 默认是 git，清空后 command 才能直接 exec sh
+    entrypoint: []
     volumes:
       - ${APP_PATH}/jeepayhomes/:/jeepayhomes
     command:


### PR DESCRIPTION
## 背景
宝塔装 jeepay，jeepay-configs 容器 exit 1，日志：
```
git: 'sh' is not a git command. See 'git --help'.
```

alpine/git 镜像 ENTRYPOINT=["git"]，command 里的 sh 被当作 git 子命令。

## Fix
加 `entrypoint: []` 清空默认 entrypoint，让 sh 作为进程入口。

本地 docker run 验证：
```
docker run --rm --entrypoint '' alpine/git:v2.45.2 sh -c 'git --version'
sh OK
git version 2.45.2
```
