### PR TITLE
fix(baota): RocketMQ healthcheck 用 bash 而不是 dash 的 /dev/tcp

### DIFF
--- a/docker-compose.baota.yml
+++ b/docker-compose.baota.yml
@@ -153,7 +153,8 @@ services:
       JAVA_OPT_EXT: "-Xms256m -Xmx256m -Xmn128m"
     command: sh mqnamesrv
     healthcheck:
-      test: ["CMD-SHELL", "echo > /dev/tcp/localhost/9876"]
+      # rocketmq 镜像里 /bin/sh 是 dash，不支持 /dev/tcp，必须显式走 bash
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/9876"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -186,7 +187,7 @@ services:
       JAVA_OPT_EXT: "-Xms512m -Xmx512m -Xmn256m"
     command: sh mqbroker -n rocketmq-namesrv:9876 -c /home/rocketmq/rocketmq-5.3.1/conf/broker.conf
     healthcheck:
-      test: ["CMD-SHELL", "echo > /dev/tcp/localhost/10911"]
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/10911"]
       interval: 15s
       timeout: 5s
       retries: 15


### PR DESCRIPTION
## 背景
宝塔装 jeepay 报：
```
dependency failed to start: container rocketmq-namesrv is unhealthy
```

## 根因
apache/rocketmq:5.3.1 里 /bin/sh 是 dash，不支持 /dev/tcp。之前写的
`["CMD-SHELL", "echo > /dev/tcp/localhost/9876"]` 等价 dash -c，
永远失败。

## Fix
`["CMD", "bash", "-c", "echo > /dev/tcp/localhost/PORT"]` 直接以 bash 执行。

本地实测 6s 内 healthy。