### PR TITLE
feat(deploy): 前端 tarball 升到 V3.0.0 + baota compose 补前端与 nginx service 名

### DIFF
--- a/docker-compose.baota.yml
+++ b/docker-compose.baota.yml
@@ -15,6 +15,7 @@
 # 环境变量（由宝塔 app 模板声明）：
 #   VERSION            业务镜像 tag（jeepay-manager/merchant/payment）
 #   CONFIG_REF         配置源 git ref（建议与 VERSION 同版本，或 master）
+#   UI_RELEASE         前端静态资源 release（默认 V3.0.0）
 #   APP_PATH           宿主机部署根目录
 #   HOST_IP            对外绑定 IP
 #   WEB_HTTP_PORT1/2/3 对外端口（分别映射到 19216 / 19217 / 19218）
@@ -66,6 +67,17 @@ services:
         cp -n /tmp/jeepay-src/conf/merchant/application.yml           /jeepayhomes/jeepayConfigs/service/merchant/application.yml  || true
         cp -n /tmp/jeepay-src/conf/payment/application.yml            /jeepayhomes/jeepayConfigs/service/payment/application.yml   || true
         cp -n /tmp/jeepay-src/docs/install/include/nginx.conf         /jeepayhomes/jeepayConfigs/nginx/nginx.conf                  || true
+        # nginx.conf 在 install.sh 场景下用 localhost:921x（nginx --net=host 可达），
+        # 但 compose 场景下 nginx 在 bridge 网络，localhost 解析不到后端。只要还能
+        # 找到 localhost:921x 就替换成 compose service 名；用户若已改过就不动。
+        if grep -q "proxy_pass http://localhost:921" /jeepayhomes/jeepayConfigs/nginx/nginx.conf 2>/dev/null; then
+            sed -i \
+                -e 's|proxy_pass http://localhost:9216|proxy_pass http://jeepaypayment:9216|g' \
+                -e 's|proxy_pass http://localhost:9217|proxy_pass http://jeepaymanager:9217|g' \
+                -e 's|proxy_pass http://localhost:9218|proxy_pass http://jeepaymerchant:9218|g' \
+                /jeepayhomes/jeepayConfigs/nginx/nginx.conf
+            echo "nginx.conf: localhost proxy_pass rewrote to compose service names"
+        fi
 
         rm -rf /jeepayhomes/jeepayConfigs/.latest
         mkdir -p /jeepayhomes/jeepayConfigs/.latest
@@ -73,6 +85,19 @@ services:
         cp -r /tmp/jeepay-src/docs/install/include                    /jeepayhomes/jeepayConfigs/.latest/include
         cp    /tmp/jeepay-src/docker/rocketmq/broker/conf/broker.conf /jeepayhomes/jeepayConfigs/.latest/broker.conf               || true
         cp    /tmp/jeepay-src/docs/sql/init.sql                       /jeepayhomes/jeepayConfigs/.latest/init.sql                  || true
+
+        # 前端静态资源（jeepay-ui 已打包发布到 gitee release）。目标目录已存在则跳过，
+        # 保护用户后续对 html/ 的改动（和 cp -n 同语义）
+        if [ ! -f /jeepayhomes/jeepayConfigs/nginx/html/jeepaymanager/index.html ]; then
+            echo "Downloading frontend html.tar.gz (release=${UI_RELEASE:-V3.0.0}) ..."
+            wget -q -O /tmp/html.tar.gz \
+                "https://gitee.com/jeequan/jeepay-ui/releases/download/${UI_RELEASE:-V3.0.0}/html.tar.gz"
+            tar xzf /tmp/html.tar.gz -C /jeepayhomes/jeepayConfigs/nginx/html/
+            rm -f /tmp/html.tar.gz
+            echo "Frontend extracted to nginx/html/"
+        else
+            echo "Frontend already present, skip download"
+        fi
 
         echo "jeepay-configs ready (user edits preserved; upstream templates in .latest/)"
     labels:

--- a/docs/deploy/baota.md
+++ b/docs/deploy/baota.md
@@ -21,6 +21,7 @@
 |---|---|---|
 | `VERSION` | 业务镜像 tag（`jeepay-manager` 等） | `3.2.0` |
 | `CONFIG_REF` | 配置源 git ref（与 `VERSION` 同版本的 tag 或 `master`） | 当前 release tag |
+| `UI_RELEASE` | 前端 `html.tar.gz` 的 `jeepay-ui` release tag | `V3.0.0` |
 | `APP_PATH` | 宿主部署根目录 | 宝塔默认 |
 | `HOST_IP` | 对外绑定 IP | 宝塔默认 |
 | `WEB_HTTP_PORT1` / `2` / `3` | 映射到容器 `19216` / `19217` / `19218` | `19216` / `19217` / `19218` |

--- a/docs/install/install.sh
+++ b/docs/install/install.sh
@@ -24,6 +24,7 @@ show_usage() {
   paymentImage                               镜像覆盖
   rocketmqPlatform                           RocketMQ 平台（默认 linux/amd64）
   jeepayRef                                  源码 tag，默认 V3.2.7
+  uiRelease                                  前端静态资源 release（默认 V3.0.0）
 EOF
 }
 while [ $# -gt 0 ]; do
@@ -676,8 +677,11 @@ echo "[6] Done. "
 
 echo "[7] 下载并启动 nginx .... "
 
+# 前端静态资源压缩包由 jeepay-ui 项目按 release 发布；可通过 uiRelease 覆盖。
+uiRelease=${uiRelease:-V3.0.0}
 cd $rootDir/nginx/html
-wget https://gitee.com/jeequan/jeepay-ui/releases/download/v1.10.0/html.tar.gz
+wget "https://gitee.com/jeequan/jeepay-ui/releases/download/${uiRelease}/html.tar.gz"
+require_ok $? "下载前端静态资源 html.tar.gz (release=${uiRelease})"
 tar -vxf html.tar.gz
 
 # 将配置文件复制到对应的映射目录下


### PR DESCRIPTION
## Summary
- install.sh 前端 tarball `v1.10.0` → `V3.0.0`，新增 `uiRelease` 覆盖变量。
- `docker-compose.baota.yml` jeepay-configs init 补两步：
  1. wget 前端 tarball 解压到 `nginx/html/`（幂等、保护用户 html 改动）
  2. sed 替换 `nginx.conf` 里 `proxy_pass http://localhost:921x` 为 compose service 名（bridge 网络必需）
- `UI_RELEASE` 新环境变量，默认 `V3.0.0`，宝塔模板可覆盖。

## Test plan
- [x] 226 服务器（amd64）端到端：8 容器全 healthy，三个平台根路径 / 收银台 / vercode 全绿
- [x] jeepay-configs 日志显式打印 "nginx.conf: localhost proxy_pass rewrote ..."
- [x] 本地 test_*.sh PASS
- [ ] PR CI 绿