### PR TITLE
fix: install git clone 失败硬退出 + 默认 MQ 切 rocketMQ 后清理 spring.activemq

### DIFF
--- a/conf/devCommons/config/application.yml
+++ b/conf/devCommons/config/application.yml
@@ -54,16 +54,16 @@ spring:
       timeout: 1000
       password:
 
-# #activeMQ配置 ( 注意： activeMQ配置项需在spring的下级 )
-  activemq:
-    broker-url: failover:(tcp://127.0.0.1:61616?wireFormat.maxInactivityDuration=0)  #连接地址
-    in-memory: false # Jeepay项目不可使用内存模式， 需要连接多个消费者。
-    user: system # activeMQ默认无需账密认证。 打开认证：activemq.xml添加simpleAuthenticationPlugin标签，账密在credentials.properties文件。
-    password: manager
-    pool:
-      enabled: true
-      max-connections: 10
-      idle-timeout: 30000  # 空闲的连接过期时间，默认为30秒
+# #activeMQ配置 ( 注意： activeMQ配置项需在spring的下级。默认 MQ 已切换到 rocketMQ，此段保留作参考；如需切回 activeMQ，请同步修改 isys.mq.vender )
+#  activemq:
+#    broker-url: failover:(tcp://127.0.0.1:61616?wireFormat.maxInactivityDuration=0)  #连接地址
+#    in-memory: false # Jeepay项目不可使用内存模式， 需要连接多个消费者。
+#    user: system # activeMQ默认无需账密认证。 打开认证：activemq.xml添加simpleAuthenticationPlugin标签，账密在credentials.properties文件。
+#    password: manager
+#    pool:
+#      enabled: true
+#      max-connections: 10
+#      idle-timeout: 30000  # 空闲的连接过期时间，默认为30秒
 #
 #  #rabbitmq配置  ( 注意： rabbitmq配置项需在spring的下级 )
 #  rabbitmq:

--- a/conf/manager/application.yml
+++ b/conf/manager/application.yml
@@ -67,16 +67,16 @@ spring:
       timeout: 1000
       password:
 
-# #activeMQ配置 ( 注意： activeMQ配置项需在spring的下级 )
-  activemq:
-    broker-url: failover:(tcp://activemq5:61616?wireFormat.maxInactivityDuration=0)  #连接地址
-    in-memory: false # Jeepay项目不可使用内存模式， 需要连接多个消费者。
-    user: system # activeMQ默认无需账密认证。 打开认证：activemq.xml添加simpleAuthenticationPlugin标签，账密在credentials.properties文件。
-    password: manager
-    pool:
-      enabled: true
-      max-connections: 10
-      idle-timeout: 30000  # 空闲的连接过期时间，默认为30秒
+# #activeMQ配置 ( 注意： activeMQ配置项需在spring的下级。默认 MQ 已切换到 rocketMQ，此段保留作参考；如需切回 activeMQ，请同步修改 isys.mq.vender )
+#  activemq:
+#    broker-url: failover:(tcp://activemq5:61616?wireFormat.maxInactivityDuration=0)  #连接地址
+#    in-memory: false # Jeepay项目不可使用内存模式， 需要连接多个消费者。
+#    user: system # activeMQ默认无需账密认证。 打开认证：activemq.xml添加simpleAuthenticationPlugin标签，账密在credentials.properties文件。
+#    password: manager
+#    pool:
+#      enabled: true
+#      max-connections: 10
+#      idle-timeout: 30000  # 空闲的连接过期时间，默认为30秒
 #
 #  #rabbitmq配置  ( 注意： rabbitmq配置项需在spring的下级 )
 #  rabbitmq:

--- a/conf/merchant/application.yml
+++ b/conf/merchant/application.yml
@@ -67,16 +67,16 @@ spring:
       timeout: 1000
       password:
 
-# #activeMQ配置 ( 注意： activeMQ配置项需在spring的下级 )
-  activemq:
-    broker-url: failover:(tcp://activemq5:61616?wireFormat.maxInactivityDuration=0)  #连接地址
-    in-memory: false # Jeepay项目不可使用内存模式， 需要连接多个消费者。
-    user: system # activeMQ默认无需账密认证。 打开认证：activemq.xml添加simpleAuthenticationPlugin标签，账密在credentials.properties文件。
-    password: manager
-    pool:
-      enabled: true
-      max-connections: 10
-      idle-timeout: 30000  # 空闲的连接过期时间，默认为30秒
+# #activeMQ配置 ( 注意： activeMQ配置项需在spring的下级。默认 MQ 已切换到 rocketMQ，此段保留作参考；如需切回 activeMQ，请同步修改 isys.mq.vender )
+#  activemq:
+#    broker-url: failover:(tcp://activemq5:61616?wireFormat.maxInactivityDuration=0)  #连接地址
+#    in-memory: false # Jeepay项目不可使用内存模式， 需要连接多个消费者。
+#    user: system # activeMQ默认无需账密认证。 打开认证：activemq.xml添加simpleAuthenticationPlugin标签，账密在credentials.properties文件。
+#    password: manager
+#    pool:
+#      enabled: true
+#      max-connections: 10
+#      idle-timeout: 30000  # 空闲的连接过期时间，默认为30秒
 #
 #  #rabbitmq配置  ( 注意： rabbitmq配置项需在spring的下级 )
 #  rabbitmq:

--- a/conf/payment/application.yml
+++ b/conf/payment/application.yml
@@ -67,16 +67,16 @@ spring:
       timeout: 1000
       password:
 
-# #activeMQ配置 ( 注意： activeMQ配置项需在spring的下级 )
-  activemq:
-    broker-url: failover:(tcp://activemq5:61616?wireFormat.maxInactivityDuration=0)  #连接地址
-    in-memory: false # Jeepay项目不可使用内存模式， 需要连接多个消费者。
-    user: system # activeMQ默认无需账密认证。 打开认证：activemq.xml添加simpleAuthenticationPlugin标签，账密在credentials.properties文件。
-    password: manager
-    pool:
-      enabled: true
-      max-connections: 10
-      idle-timeout: 30000  # 空闲的连接过期时间，默认为30秒
+# #activeMQ配置 ( 注意： activeMQ配置项需在spring的下级。默认 MQ 已切换到 rocketMQ，此段保留作参考；如需切回 activeMQ，请同步修改 isys.mq.vender )
+#  activemq:
+#    broker-url: failover:(tcp://activemq5:61616?wireFormat.maxInactivityDuration=0)  #连接地址
+#    in-memory: false # Jeepay项目不可使用内存模式， 需要连接多个消费者。
+#    user: system # activeMQ默认无需账密认证。 打开认证：activemq.xml添加simpleAuthenticationPlugin标签，账密在credentials.properties文件。
+#    password: manager
+#    pool:
+#      enabled: true
+#      max-connections: 10
+#      idle-timeout: 30000  # 空闲的连接过期时间，默认为30秒
 #
 #  #rabbitmq配置  ( 注意： rabbitmq配置项需在spring的下级 )
 #  rabbitmq:

--- a/docs/install/install.sh
+++ b/docs/install/install.sh
@@ -411,6 +411,7 @@ jeepayRef=${jeepayRef:-V3.2.7}
 echo "[2] 拉取项目源代码文件 (ref=$jeepayRef).... "
 cd $rootDir/sources
 git clone --branch "$jeepayRef" --depth 1 https://gitee.com/jeequan/jeepay.git
+require_ok $? "拉取 jeepay 源码 (ref=$jeepayRef)。若 tag 尚未推送到 gitee，请改用 jeepayRef=master 覆盖或稍后重试。"
 echo "[2] Done. "
 
 #源码中install.sh文件目录


### PR DESCRIPTION
本 PR 含 2 个独立修复，合到 dev 进入下个补丁版（V3.2.9）。

---

## 修复 1：install.sh git clone 失败硬退出

### 背景

用户使用主干 `install.sh` 部署时踩坑：

```
install.sh: 第 449 行:cd: /jeepayhomes/sources/jeepay/docs/install: No such file or directory
ERROR: 步骤失败（exit=1）：复制 MySQL 配置 my.cnf
```

真实根因是 `git clone --branch $jeepayRef` 失败（V3.2.8 tag 刚 push 到 GitHub，还没镜像到 gitee），`jeepay/` 目录压根没创建，但脚本没断言，继续往下跑到 `[3] 复制 MySQL 配置 my.cnf` 才爆一个文不对题的错，让用户误以为是 MySQL 步骤的问题。

### 变更

- `docs/install/install.sh` line 413 的 `git clone` 之后加 `require_ok $?`，错误信息里直接告诉用户"若 tag 尚未推送到 gitee，请改用 jeepayRef=master 覆盖或稍后重试"。

### 验证

- `bash -n install.sh` 语法校验通过。
- 触发路径：将 `jeepayRef` 设为一个不存在的 tag 再跑，应在 [2] 阶段立刻退出，不再往后走。

---

## 修复 2：默认 MQ 切 rocketMQ 后清理 spring.activemq 配置（修复 #105）

### 背景

issue #105 反馈：默认 `isys.mq.vender` 已是 `rocketMQ`，但 `conf/` 下 4 份 `application.yml` 里 `spring.activemq.*` 段仍保持启用状态，读起来跟底部 vender 配置自相矛盾。

定位到根因：`e2dc439 优化：默认切换 RocketMQ 部署方案` 那次提交只改了底部 vender 和加了 rocketmq 根节点，漏注释掉 spring 段的 activemq 配置。

实际影响：`jeepay-components-mq/pom.xml` 里 `spring-boot-starter-activemq` 是 compile scope，Spring Boot 启动仍会解析这段配置并尝试连 `activemq5:61616`（`failover://` 不报错，后台一直重连），产生噪音和资源占用，也让阅读者误以为系统在用 activeMQ。

### 变更

按已有 `rabbitmq` / `rocketmq(spring 段)` 注释惯例，把 `conf/{payment,manager,merchant,devCommons/config}/application.yml` 4 份模板里的 `spring.activemq` 段也注释掉，并在标题注里加了说明：默认 rocketMQ，如需切回 activeMQ 请同步改 `isys.mq.vender`。

### 验证

- [ ] 部署到默认 RocketMQ 环境，启动日志不再出现尝试连 `activemq5:61616` 的 failover 重连
- [ ] 把 `isys.mq.vender` 改回 `activeMQ` 并放开 spring.activemq 注释，确认仍能正常起 activemq 模式（兼容性）

---

## 发布节奏

作为下个补丁版（V3.2.9）的修复入 dev。本 PR 不改 version.md / jeepayRef 默认值，由 V3.2.9 发版本 PR 集中撞版本号。