### PR TITLE
fix(alipay): 加固授权回调 state 解析 + 异步通知补业务字段交叉校验

### DIFF
--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/AlipayChannelNoticeService.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/AlipayChannelNoticeService.java
@@ -23,15 +23,18 @@ import com.jeequan.jeepay.core.exception.ResponseException;
 import com.jeequan.jeepay.core.model.params.alipay.AlipayConfig;
 import com.jeequan.jeepay.core.model.params.alipay.AlipayIsvParams;
 import com.jeequan.jeepay.core.model.params.alipay.AlipayNormalMchParams;
+import com.jeequan.jeepay.core.utils.AmountUtil;
 import com.jeequan.jeepay.pay.channel.AbstractChannelNoticeService;
 import com.jeequan.jeepay.pay.model.MchAppConfigContext;
 import com.jeequan.jeepay.pay.rqrs.msg.ChannelRetMsg;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.math.BigDecimal;
 import java.util.Map;
 
 /*
@@ -75,6 +78,7 @@ public class AlipayChannelNoticeService extends AbstractChannelNoticeService {
             //配置参数获取
             Byte useCert = null;
             String alipaySignType, alipayPublicCert, alipayPublicKey = null;
+            String expectedAppId; // 业务字段交叉校验用
             if(mchAppConfigContext.isIsvsubMch()){
 
                 // 获取支付参数
@@ -83,6 +87,7 @@ public class AlipayChannelNoticeService extends AbstractChannelNoticeService {
                 alipaySignType = alipayParams.getSignType();
                 alipayPublicCert = alipayParams.getAlipayPublicCert();
                 alipayPublicKey = alipayParams.getAlipayPublicKey();
+                expectedAppId = alipayParams.getAppId();
 
             }else{
 
@@ -93,6 +98,7 @@ public class AlipayChannelNoticeService extends AbstractChannelNoticeService {
                 alipaySignType = alipayParams.getSignType();
                 alipayPublicCert = alipayParams.getAlipayPublicCert();
                 alipayPublicKey = alipayParams.getAlipayPublicKey();
+                expectedAppId = alipayParams.getAppId();
             }
 
             // 获取请求参数
@@ -111,6 +117,33 @@ public class AlipayChannelNoticeService extends AbstractChannelNoticeService {
             //验签失败
             if(!verifyResult){
                 throw ResponseException.buildText("ERROR");
+            }
+
+            // 业务字段交叉校验：验签通过仅证明请求来自支付宝并由本商户密钥签名，
+            // 不保证回调内容就是这笔本地订单。多商户配置切换 / 跨订单签名穿越 / 沙箱与生产串扰
+            // 等场景下，仍可能出现 out_trade_no、金额、app_id 与本地订单上下文不一致的回调。
+            // 任一字段不一致 → 记 ERROR 日志 + 返回 SUCCESS 阻断支付宝重试 8 次 + 不更新订单状态。
+            String notifyOutTradeNo = jsonParams.getString("out_trade_no");
+            String notifyAppId = jsonParams.getString("app_id");
+            String notifyTotalAmount = jsonParams.getString("total_amount");
+            String expectedTotalAmount = AmountUtil.convertCent2Dollar(payOrder.getAmount());
+            boolean amountMatch;
+            try {
+                amountMatch = new BigDecimal(notifyTotalAmount).compareTo(new BigDecimal(expectedTotalAmount)) == 0;
+            } catch (NumberFormatException e) {
+                amountMatch = false;
+            }
+            if (!StringUtils.equals(notifyOutTradeNo, payOrder.getPayOrderId())
+                    || !StringUtils.equals(notifyAppId, expectedAppId)
+                    || !amountMatch) {
+                log.error("支付宝异步回调业务字段不匹配，已拒绝处理。out_trade_no=[{}] expected=[{}]; app_id=[{}] expected=[{}]; total_amount=[{}] expected=[{}]",
+                        notifyOutTradeNo, payOrder.getPayOrderId(),
+                        notifyAppId, expectedAppId,
+                        notifyTotalAmount, expectedTotalAmount);
+                ChannelRetMsg dropped = new ChannelRetMsg();
+                dropped.setResponseEntity(textResp("SUCCESS"));
+                dropped.setChannelState(ChannelRetMsg.ChannelState.UNKNOWN);
+                return dropped;
             }
 
             //验签成功后判断上游订单状态

--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/AlipayKit.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/AlipayKit.java
@@ -27,6 +27,8 @@ import com.jeequan.jeepay.core.utils.SpringBeansUtil;
 import com.jeequan.jeepay.pay.model.MchAppConfigContext;
 import com.jeequan.jeepay.pay.service.ConfigContextQueryService;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 
 /*
 * 【支付宝】支付通道工具包
@@ -106,6 +108,30 @@ public class AlipayKit {
 
     public static String appendErrCode(String code, String subCode){
         return StringUtils.defaultIfEmpty(subCode, code); //优先： subCode
+    }
+
+    /**
+     * 解析支付宝授权回调中拼接的 state 参数（格式：ISVNO_MCHAPPID）。
+     *
+     * 历史上 controller 直接写 split("_")[0]/[1]，没做边界校验：
+     * 空串、不含 "_"、或者 "_" 在首尾的输入都会触发 ArrayIndexOutOfBoundsException
+     * 或得到空字符串，进而被恶意构造的请求触发回调链路 500。
+     *
+     * 使用 indexOf 取第一个 "_" 切分，而不是 split，避免 mchAppId 内部含 "_" 时被切碎。
+     *
+     * @return ImmutablePair(isvNo, mchAppId)；解析失败返回 null，由调用方决定如何提示
+     */
+    public static Pair<String, String> parseIsvAndMchAppIdState(String state) {
+        if (StringUtils.isEmpty(state)) {
+            return null;
+        }
+        int idx = state.indexOf('_');
+        // idx <= 0：没有 "_" 或 "_" 在最前面（isvNo 为空）
+        // idx >= state.length() - 1：" _" 在最后（mchAppId 为空）
+        if (idx <= 0 || idx >= state.length() - 1) {
+            return null;
+        }
+        return ImmutablePair.of(state.substring(0, idx), state.substring(idx + 1));
     }
 
     public static String appendErrMsg(String msg, String subMsg){

--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/ctrl/AlipayBizController.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/alipay/ctrl/AlipayBizController.java
@@ -38,6 +38,7 @@ import com.jeequan.jeepay.service.impl.PayInterfaceConfigService;
 import com.jeequan.jeepay.service.impl.SysConfigService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -73,10 +74,16 @@ public class AlipayBizController extends AbstractCtrl {
     @RequestMapping("/redirectAppToAppAuth/{isvAndMchAppId}")
     public void redirectAppToAppAuth(@PathVariable("isvAndMchAppId") String isvAndMchAppId) throws IOException {
 
-        String isvNo = isvAndMchAppId.split("_")[0];
+        Pair<String, String> parsed = AlipayKit.parseIsvAndMchAppIdState(isvAndMchAppId);
+        if (parsed == null) {
+            throw new BizException("授权参数非法：isvAndMchAppId 格式应为 ISVNO_MCHAPPID");
+        }
+        String isvNo = parsed.getLeft();
 
         AlipayIsvParams alipayIsvParams = (AlipayIsvParams) configContextQueryService.queryIsvParams(isvNo, CS.IF_CODE.ALIPAY);
-        alipayIsvParams.getSandbox();
+        if (alipayIsvParams == null) {
+            throw new BizException("ISV [" + isvNo + "] 未配置支付宝参数");
+        }
 
         String oauthUrl = AlipayConfig.PROD_APP_TO_APP_AUTH_URL;
         if(alipayIsvParams.getSandbox() != null && alipayIsvParams.getSandbox() == CS.YES){
@@ -101,10 +108,17 @@ public class AlipayBizController extends AbstractCtrl {
 
             if(StringUtils.isNotEmpty(isvAndMchAppId) && StringUtils.isNotEmpty(appAuthCode)){
                 isAlipaySysAuth = false;
-                String isvNo = isvAndMchAppId.split("_")[0];
-                String mchAppId = isvAndMchAppId.split("_")[1];
+
+                Pair<String, String> parsed = AlipayKit.parseIsvAndMchAppIdState(isvAndMchAppId);
+                if (parsed == null) {
+                    throw new BizException("授权回调 state 格式非法：应为 ISVNO_MCHAPPID");
+                }
+                String mchAppId = parsed.getRight();
 
                 MchApp mchApp = mchAppService.getById(mchAppId);
+                if (mchApp == null) {
+                    throw new BizException("商户应用 [" + mchAppId + "] 不存在");
+                }
 
                 MchAppConfigContext mchAppConfigContext = configContextQueryService.queryMchInfoAndAppInfo(mchApp.getMchNo(), mchAppId);
                 AlipayClientWrapper alipayClientWrapper = configContextQueryService.getAlipayClientWrapper(mchAppConfigContext);


### PR DESCRIPTION
## 背景

修复 #81（感谢 @xiaowuDev 提交的 PR 描述定位到这两处问题，原 PR 关闭后由本 PR 重新实现）。

## 修复 1：授权回调 state 参数解析鲁棒性

**原问题**：`AlipayBizController` 的 `redirectAppToAppAuth` 和 `appToAppAuthCallback` 都直接 `isvAndMchAppId.split("_")[0]/[1]`，未做长度 / 空值 / 空串校验。异常或被构造的 state（如 \`/redirectAppToAppAuth/badid\` 或 state 为空字符串）会触发 `ArrayIndexOutOfBoundsException` 或空指针，回调链路出现 500。

**修复**：
- 抽出 `AlipayKit.parseIsvAndMchAppIdState(String)` 工具方法：用 `indexOf` 而非 `split`（避免 mchAppId 内部含 `_` 时被切碎），任一段为空返回 null
- 两个回调入口改用工具方法 + null 校验 + `mchAppService.getById` 结果空校验，抛 `BizException` 由现有异常处理统一展示
- 顺手清理 `redirectAppToAppAuth` 里两行无效代码（`getSandbox()` 返回值未使用、`isvNo` 局部变量从未读取）

## 修复 2：异步通知业务字段交叉校验

**原问题**：`AlipayChannelNoticeService.doNotice` 验签通过后直接信任 `jsonParams`，仅取了 `trade_no` / `buyer_id` / `trade_status` 来设置 `ChannelRetMsg`。验签通过仅证明请求来自支付宝并由本商户密钥签名，**不保证回调内容就是这笔本地订单**。多商户配置切换、跨订单签名穿越、沙箱与生产串扰等场景下，仍可能出现 `out_trade_no` / 金额 / `app_id` 与本地订单上下文不一致的回调，按现有逻辑会把这笔"看似合法"的回调直接当成功回写订单，造成错单和账务异常。

**修复**：在验签通过后、设置 `ChannelRetMsg` 前补一道校验：
- `out_trade_no` 必须等于 `payOrder.payOrderId`
- `app_id` 必须等于商户配置里的 `appId`（ISV/普通商户分别取对应配置）
- `total_amount`（元）必须等于本地金额（分→元，用 `BigDecimal.compareTo` 比对，避免 scale 差异）

任一字段不一致：
- 记 ERROR 日志，带具体不匹配的字段与双方值，方便运维排查
- 返回 `SUCCESS` 给支付宝，阻断 8 次重试浪费资源
- `ChannelState` 设为 `UNKNOWN`（而非 `CONFIRM_FAIL`，避免被下游误判为"确认失败"触发退款补偿逻辑）
- 订单状态不更新，保持原状

## 不做的事

- **不校验 `seller_id`**：`AlipayNormalMchParams` 当前没存 PID 字段，强行做要么改 schema 要么改 channelExtra，破坏面太大，留到未来需要时再补。`app_id` 校验已能拦截 PR #81 描述的主要场景。
- **不补单元测试**：与项目惯例一致，`jeepay-payment/src/test` 是空目录占位状态；校验逻辑组织成纯静态方法 / 局部变量，便于未来引入测试基础设施时补。

## 验证

- [x] `mvn -pl jeepay-payment -am compile` 通过
- [ ] 构造测试场景验证：state=空 / state=\`badid\` / state=\`isv_\` / state=\`_mch\` 都被拒绝返回 4xx 而非 500
- [ ] 构造测试场景验证：异步回调 `out_trade_no` 与本地订单不一致 / `total_amount` 不一致 / `app_id` 不一致 时返回 SUCCESS 但订单状态不变，日志能看到 ERROR 行

## 发布节奏

下个补丁版（V3.2.9）一起发出。本 PR 不改 version.md，由 V3.2.9 发版本 PR 集中撞版本号。