### PR TITLE
docs(readme): 增加 AI 接入助手段，引导到 jeepay-skills 仓库

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,14 @@ Jeepay 已提供 Java、Python SDK，以及 PHP 对接 Demo：
 - SDK 下载地址：<https://doc.jeequan.com/#/integrate/open/api/116>
 - Java SDK 仓库：<https://github.com/jeequan/jeepay-sdk-java>
 
+## AI 接入助手
+
+如果你用 Claude / Cursor / ChatGPT 等 AI 工具接入 Jeepay，可以使用 [Jeepay Skills](https://github.com/jeequan/jeepay-skills) —— 把签名陷阱、字段大小写、wayCode 选择等 AI 容易踩坑的细节系统化整理，让 AI 一次接对。
+
+- 仓库地址：<https://github.com/jeequan/jeepay-skills>
+- 支持 Claude Code / Cursor / Cline / 网页 AI（claude.ai · ChatGPT · 通义千问 · 文心一言）
+- 也可作为纯文档浏览，不用 AI 也能直接看接入指南
+
 ## 项目地址
 
 - 服务端：[GitHub](https://github.com/jeequan/jeepay) · [Gitee](https://gitee.com/jeequan/jeepay) · [GitCode](https://gitcode.com/jeequantech/jeepay)


### PR DESCRIPTION
## 背景

[jeepay-skills](https://github.com/jeequan/jeepay-skills) 仓库已发出 v1.0.0，是给用 Claude / Cursor / ChatGPT 等 AI 工具接入 Jeepay 的开发者准备的结构化接入助手套件。Jeepay 主仓库 README 需要一个入口指向它，让现有 Jeepay 用户能发现并使用。

## 改动

在「文档与资源 → SDK 资源」段之后新增「AI 接入助手」小节，内容：

- 仓库地址：https://github.com/jeequan/jeepay-skills
- 列出支持的 AI 工具范围（Claude Code / Cursor / Cline / 网页 AI）
- 说明不用 AI 也能当纯文档浏览

只是文档变更，不影响代码、不影响构建。

## Test plan

- [ ] 切到 PR 分支预览 README 渲染效果，确认「AI 接入助手」小节位置合理、链接可点
- [ ] 点 https://github.com/jeequan/jeepay-skills 确认仓库可访问、首页 README 完整