### PR TITLE
fix(pppay): 修复非缓存模式下 PayPal 回调 PaypalWrapper 为 null

### DIFF
--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/pppay/PppayChannelNoticeService.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/pppay/PppayChannelNoticeService.java
@@ -72,8 +72,8 @@ public class PppayChannelNoticeService extends AbstractChannelNoticeService {
         JSONObject object = (JSONObject) params;
         // 获取 Paypal 订单 ID
         String ppOrderId = object.getStr("token");
-        // 统一处理订单
-        return mchAppConfigContext.getPaypalWrapper().processOrder(ppOrderId, payOrder);
+        // 通过 ConfigContextQueryService 获取 PaypalWrapper，兼容缓存和非缓存模式
+        return configContextQueryService.getPaypalWrapper(mchAppConfigContext).processOrder(ppOrderId, payOrder);
     }
 
     public ChannelRetMsg doNotify(HttpServletRequest request, Object params, PayOrder payOrder,
@@ -81,7 +81,7 @@ public class PppayChannelNoticeService extends AbstractChannelNoticeService {
         JSONObject object = (JSONObject) params;
         // 获取 Paypal 订单 ID
         String ppOrderId = object.getByPath("resource.id", String.class);
-        // 统一处理订单
-        return mchAppConfigContext.getPaypalWrapper().processOrder(ppOrderId, payOrder, true);
+        // 通过 ConfigContextQueryService 获取 PaypalWrapper，兼容缓存和非缓存模式
+        return configContextQueryService.getPaypalWrapper(mchAppConfigContext).processOrder(ppOrderId, payOrder, true);
     }
 }

--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/pppay/PppayChannelRefundNoticeService.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/channel/pppay/PppayChannelRefundNoticeService.java
@@ -51,7 +51,8 @@ public class PppayChannelRefundNoticeService extends AbstractChannelRefundNotice
             JSONObject object = (JSONObject) params;
             String orderId = object.getByPath("resource.id", String.class);
 
-            PaypalWrapper wrapper = mchAppConfigContext.getPaypalWrapper();
+            // 通过 ConfigContextQueryService 获取 PaypalWrapper，兼容缓存和非缓存模式
+            PaypalWrapper wrapper = configContextQueryService.getPaypalWrapper(mchAppConfigContext);
             PayPalHttpClient client = wrapper.getClient();
 
             // 查询退款详情以及状态


### PR DESCRIPTION
标题：fix(pppay): 修复非缓存模式下 PayPal 回调 PaypalWrapper 为 null

描述：


## 问题

当 `cache-config: false`（非缓存模式）时，PayPal 支付回调（同步跳转和异步通知）均会抛出 NPE，
导致 Capture 未执行，用户已授权但实际未扣款。

根因：`PppayChannelNoticeService` 和 `PppayChannelRefundNoticeService` 中
直接通过 `mchAppConfigContext.getPaypalWrapper()` 获取 PayPal 客户端，
而 `ConfigContextQueryService.queryMchInfoAndAppInfo()` 在非缓存模式下
构建的 `MchAppConfigContext` 未初始化 `paypalWrapper`，导致返回 null。

## 修复

改为与微信通道一致的写法，通过 `configContextQueryService.getPaypalWrapper(mchAppConfigContext)`
获取，该方法内部兼容了缓存和非缓存两种模式。

## 影响范围

- `PppayChannelNoticeService`：doReturn / doNotify 两处
- `PppayChannelRefundNoticeService`：doNotice 一处

## 测试

PayPal Sandbox 环境测试通过，同步回调正常触发 Capture，订单状态正确更新为支付成功。